### PR TITLE
ci: harden Swift SDK E2E health checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,7 +420,9 @@ jobs:
       EDGEBASE_E2E_REQUIRED: "1"
       EDGEBASE_TEST_LOG_PATH: /tmp/edgebase-swift-e2e-server.log
       EDGEBASE_TEST_PID_PATH: /tmp/edgebase-swift-e2e-server.pid
-      EDGEBASE_E2E_HEALTHCHECK_TIMEOUT_MS: "8000"
+      EDGEBASE_E2E_HEALTHCHECK_TIMEOUT_MS: "15000"
+      EDGEBASE_E2E_HEALTHCHECK_RETRIES: "3"
+      EDGEBASE_E2E_HEALTHCHECK_RETRY_DELAY_MS: "1000"
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -447,17 +449,22 @@ jobs:
             exit "$status"
           }
           trap cleanup EXIT
+          ROOT_DIR="$(pwd)"
+          run_swift_suite() {
+            bash "$ROOT_DIR/scripts/wait-for-test-server.sh"
+            swift test --filter "$1"
+          }
           bash ./scripts/start-test-server.sh
           bash ./scripts/wait-for-test-server.sh
           cd packages/sdk/swift/packages/core
-          swift test --filter E2ETests
+          run_swift_suite E2ETests
           cd ../ios
-          swift test --filter EdgeBaseClientIosE2ETests
-          swift test --filter IosAuthExtendedE2ETests
-          swift test --filter IosDbExtendedE2ETests
-          swift test --filter IosStorageAuthE2ETests
-          swift test --filter IosRoomE2ETests
-          swift test --filter IosSwiftLangE2ETests
+          run_swift_suite EdgeBaseClientIosE2ETests
+          run_swift_suite IosAuthExtendedE2ETests
+          run_swift_suite IosDbExtendedE2ETests
+          run_swift_suite IosStorageAuthE2ETests
+          run_swift_suite IosRoomE2ETests
+          run_swift_suite IosSwiftLangE2ETests
           EOF
 
   # ─── Mutation Testing (PR only) ─────────────────────────────────────────────

--- a/packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift
+++ b/packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift
@@ -9,9 +9,23 @@ import XCTest
 private enum E2ETestSupport {
     private static let requiredEnv = "EDGEBASE_E2E_REQUIRED"
     private static let timeoutEnv = "EDGEBASE_E2E_HEALTHCHECK_TIMEOUT_MS"
+    private static let retryCountEnv = "EDGEBASE_E2E_HEALTHCHECK_RETRIES"
+    private static let retryDelayEnv = "EDGEBASE_E2E_HEALTHCHECK_RETRY_DELAY_MS"
 
     static func requireServer(_ baseUrl: String) throws {
-        guard !isServerAvailable(baseUrl) else { return }
+        let retryCount = max(Int(ProcessInfo.processInfo.environment[retryCountEnv] ?? "") ?? 3, 1)
+        let retryDelayMs = max(Double(ProcessInfo.processInfo.environment[retryDelayEnv] ?? "") ?? 1000, 200)
+
+        for attempt in 1...retryCount {
+            if isServerAvailable(baseUrl) {
+                return
+            }
+
+            if attempt < retryCount {
+                Thread.sleep(forTimeInterval: retryDelayMs / 1000.0)
+            }
+        }
+
         let message = "E2E backend not reachable at \(baseUrl). Start `edgebase dev --port 8688` or set BASE_URL. Set \(requiredEnv)=1 to fail instead of skip."
         if ProcessInfo.processInfo.environment[requiredEnv] == "1" {
             throw NSError(domain: "EdgeBaseE2E", code: 1, userInfo: [NSLocalizedDescriptionKey: message])

--- a/scripts/wait-for-test-server.sh
+++ b/scripts/wait-for-test-server.sh
@@ -6,19 +6,40 @@ PORT="${EDGEBASE_TEST_PORT:-8688}"
 BASE_URL="${BASE_URL:-http://localhost:${PORT}}"
 TIMEOUT_SECONDS="${EDGEBASE_TEST_STARTUP_TIMEOUT_SECONDS:-90}"
 LOG_PATH="${EDGEBASE_TEST_LOG_PATH:-}"
+PID_PATH="${EDGEBASE_TEST_PID_PATH:-}"
 START_TIME=$SECONDS
 
+print_log_tail() {
+  if [[ -n "$LOG_PATH" && -f "$LOG_PATH" ]]; then
+    echo "--- server log tail ---"
+    tail -n 200 "$LOG_PATH" || true
+    echo "--- end server log tail ---"
+  fi
+}
+
+check_server_process() {
+  if [[ -z "$PID_PATH" || ! -f "$PID_PATH" ]]; then
+    return
+  fi
+
+  local pid
+  pid="$(cat "$PID_PATH" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+    echo "EdgeBase test server process is not running (pid: ${pid})"
+    print_log_tail
+    exit 1
+  fi
+}
+
 until curl -fsS "${BASE_URL}/api/health" >/dev/null 2>&1; do
+  check_server_process
   if (( SECONDS - START_TIME >= TIMEOUT_SECONDS )); then
     echo "Timed out waiting for EdgeBase test server at ${BASE_URL}"
-    if [[ -n "$LOG_PATH" && -f "$LOG_PATH" ]]; then
-      echo "--- server log tail ---"
-      tail -n 200 "$LOG_PATH" || true
-      echo "--- end server log tail ---"
-    fi
+    print_log_tail
     exit 1
   fi
   sleep 2
 done
 
+check_server_process
 echo "EdgeBase test server is healthy at ${BASE_URL}"


### PR DESCRIPTION
## Summary
- add retry-aware Swift E2E server health checks
- re-check server health before each Swift E2E suite
- fail faster with server PID/log diagnostics when the test server dies

## Why
The Swift SDK E2E job intermittently failed in `IosRoomE2ETests.test_room_join_with_auth` because the backend at `http://localhost:8688` became unreachable during the run. Re-running the failed job passed, which points to infrastructure/test flakiness rather than a docs regression.

## Validation
- `bash -n scripts/wait-for-test-server.sh`
- `git diff --check`
- `swift test --filter IosRoomE2ETests` (serverless compile/skip path)