### PR TITLE
tests(cli): call local `tsx` binary directly instead of using `pnpm exec`

### DIFF
--- a/packages/cli/test/cli-entrypoint-agent-mode.test.ts
+++ b/packages/cli/test/cli-entrypoint-agent-mode.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +14,20 @@ function createHomeDir(): string {
   return dir;
 }
 
+function resolveTsxCommand(): string {
+  const binaryName = process.platform === 'win32' ? 'tsx.cmd' : 'tsx';
+  const candidates = [
+    join(packageDir, 'node_modules', '.bin', binaryName),
+    join(packageDir, '..', '..', 'node_modules', '.bin', binaryName),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return 'tsx';
+}
+
 describe('CLI entrypoint agent mode', () => {
   afterEach(() => {
     for (const dir of tempDirs.splice(0)) {
@@ -24,9 +38,7 @@ describe('CLI entrypoint agent mode', () => {
   it('returns structured needs_input JSON for export when --table is missing', () => {
     const homeDir = createHomeDir();
 
-    const result = spawnSync('pnpm', [
-      'exec',
-      'tsx',
+    const result = spawnSync(resolveTsxCommand(), [
       'src/index.ts',
       '--json',
       '--non-interactive',
@@ -69,9 +81,7 @@ describe('CLI entrypoint agent mode', () => {
       databases: {},
     }));
 
-    const result = spawnSync('pnpm', [
-      'exec',
-      'tsx',
+    const result = spawnSync(resolveTsxCommand(), [
       'src/index.ts',
       '--json',
       '--non-interactive',

--- a/packages/cli/test/cli-entrypoint-telemetry.test.ts
+++ b/packages/cli/test/cli-entrypoint-telemetry.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,8 +14,22 @@ function createHomeDir(): string {
   return dir;
 }
 
+function resolveTsxCommand(): string {
+  const binaryName = process.platform === 'win32' ? 'tsx.cmd' : 'tsx';
+  const candidates = [
+    join(packageDir, 'node_modules', '.bin', binaryName),
+    join(packageDir, '..', '..', 'node_modules', '.bin', binaryName),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return 'tsx';
+}
+
 function runCli(homeDir: string, args: string[]): string {
-  return execFileSync('pnpm', ['exec', 'tsx', 'src/index.ts', ...args], {
+  return execFileSync(resolveTsxCommand(), ['src/index.ts', ...args], {
     cwd: packageDir,
     encoding: 'utf-8',
     env: {
@@ -69,7 +83,7 @@ describe('CLI entrypoint telemetry', () => {
 
     runCli(homeDir, ['telemetry', 'enable']);
 
-    const result = spawnSync('pnpm', ['exec', 'tsx', 'src/index.ts', 'definitely-missing'], {
+    const result = spawnSync(resolveTsxCommand(), ['src/index.ts', 'definitely-missing'], {
       cwd: packageDir,
       encoding: 'utf-8',
       env: {


### PR DESCRIPTION
### Motivation

- Make CLI tests independent of `pnpm` and more robust across different install layouts by invoking the `tsx` binary directly.

### Description

- Add a `resolveTsxCommand` helper to test files that locates `node_modules/.bin/tsx` (with a fallback to `'tsx'`) and import `existsSync` to check candidates.
- Replace invocations of `pnpm exec tsx` in tests with direct calls to `spawnSync(resolveTsxCommand(), ...)` and `execFileSync(resolveTsxCommand(), ...)`.
- Apply the change in `cli-entrypoint-agent-mode.test.ts` and `cli-entrypoint-telemetry.test.ts` so tests run without relying on `pnpm` in the environment.

### Testing

- Ran the `packages/cli` test suite under Vitest, including `cli-entrypoint-agent-mode.test.ts` and `cli-entrypoint-telemetry.test.ts`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3ac89a248327a73005cb0eb9eb40)