### PR TITLE
fix: include SDP offer in Cloudflare Realtime session creation

### DIFF
--- a/packages/sdk/js/packages/web/src/room-realtime-media.ts
+++ b/packages/sdk/js/packages/web/src/room-realtime-media.ts
@@ -175,8 +175,21 @@ export class RoomRealtimeMediaTransport {
     this.peerConnection = this.options.peerConnectionFactory(configuration);
     this.peerConnection.ontrack = (event) => this.handleRemoteTrack(event);
 
-    const response = await this.room.media.realtime.createSession(payload);
+    // Generate an initial SDP offer for session creation.
+    // Cloudflare Realtime requires a sessionDescription when creating a new session.
+    const initialOffer = await this.createLocalOffer();
+    const sessionPayload: RoomRealtimeCreateSessionRequest = {
+      ...payload,
+      sessionDescription: payload?.sessionDescription ?? initialOffer,
+    };
+
+    const response = await this.room.media.realtime.createSession(sessionPayload);
     this.sessionId = response.sessionId;
+
+    // Apply the response sessionDescription (answer) from Cloudflare
+    if (response.sessionDescription) {
+      await this.peerConnection.setRemoteDescription(response.sessionDescription);
+    }
 
     this.attachRoomSubscriptions();
     await this.subscribeExistingPublishedTracks();


### PR DESCRIPTION
## Summary

- Cloudflare Realtime API now requires a `sessionDescription` (SDP offer) when creating a new session via `POST /sessions/new`
- The `connect()` method in `RoomRealtimeMediaTransport` was calling `createSession()` without generating an SDP offer first, causing `"Body JSON validation error: sessionDescription"`
- This fix generates an initial SDP offer from the PeerConnection before calling `createSession()`, and applies the response SDP answer to complete the WebRTC handshake

## Reproduction

```typescript
const transport = room.media.realtime.transport({ autoSubscribe: true });
await transport.connect(); // Throws: "Body JSON validation error: sessionDescription"
```

## Changes

**`packages/sdk/js/packages/web/src/room-realtime-media.ts`**
- Generate SDP offer via `createLocalOffer()` before calling `createSession()`
- Include the offer as `sessionDescription` in the session creation payload
- Apply the response `sessionDescription` (answer) from Cloudflare to complete the WebRTC handshake
- Preserve backward compatibility: if caller passes their own `sessionDescription` via payload, it takes precedence

## Test plan

- [ ] Verify `transport.connect()` succeeds without `sessionDescription` validation error
- [ ] Verify audio/video/screen share publishing works after session creation
- [ ] Verify remote track subscription works correctly
- [ ] Test with `turn: true` and `turn: false` configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)