### PR TITLE
fix: normalize database constraint errors in DatabaseDO

### DIFF
--- a/packages/server/src/durable-objects/database-do.ts
+++ b/packages/server/src/durable-objects/database-do.ts
@@ -48,7 +48,7 @@ import {
   type FilterTuple,
 } from '../lib/query-engine.js';
 import { summarizeValidationErrors, validateInsert, validateUpdate } from '../lib/validation.js';
-import { hookRejectedError, validationError, notFoundError } from '../lib/errors.js';
+import { hookRejectedError, validationError, notFoundError, normalizeDatabaseError } from '../lib/errors.js';
 import {
   executeDbTriggers,
   getRegisteredFunctions,
@@ -1935,6 +1935,11 @@ export class DatabaseDO extends DurableObject<DOEnv> {
       if ('code' in err && typeof (err as Record<string, unknown>).code === 'number') {
         const e = err as { code: number; message: string; data?: unknown };
         return c.json({ code: e.code, message: e.message, data: e.data }, e.code as 200);
+      }
+      // Normalize well-known database errors (e.g. UNIQUE constraint violations → 409)
+      const normalizedDbError = normalizeDatabaseError(err);
+      if (normalizedDbError) {
+        return c.json(normalizedDbError.toJSON(), normalizedDbError.code as 400);
       }
       console.error('DatabaseDO Error:', err);
       return c.json({ code: 500, message: 'Internal server error.' }, 500);


### PR DESCRIPTION
## Summary
- DatabaseDO's `app.onError()` handler was missing `normalizeDatabaseError()`, causing raw SQLite constraint violations (e.g. UNIQUE constraint failed) to return generic **500 Internal Server Error** instead of a proper **409 Conflict** with a descriptive message.
- D1 handler and PostgreSQL handler (via global `errorHandlerMiddleware`) already normalize these errors correctly — this change aligns the Durable Object backend with the same behavior.
- One-line fix: adds `normalizeDatabaseError()` call before the generic 500 fallback in `database-do.ts`.

## Test plan
- [ ] Insert a record with a duplicate value on a `unique: true` field via DO backend
- [ ] Verify response is `409` with `"record-already-exists"` slug instead of `500`
- [ ] Verify existing error handling (EdgeBaseError, duck-typed errors) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)