### PR TITLE
ci: skip Snyk CI on rate/quota limit instead of failing PR

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -91,7 +91,7 @@ jobs:
           elif grep -Eiq 'SNYK-CODE-0005|snyk code is not enabled|not supported for your current organization|activate snyk code' snyk-code.log; then
             outcome="skip"
             reason="code-not-enabled"
-          elif grep -Eiq 'test limit|rate limit|too many requests|quota|payment required|unauthorized|forbidden|authentication failed|failed to authenticate|access denied|service unavailable|temporarily unavailable|organization .* not found' snyk-code.log; then
+          elif grep -Eiq 'test limit|rate limit|reached .* limit|too many requests|quota|payment required|unauthorized|forbidden|authentication failed|failed to authenticate|access denied|service unavailable|temporarily unavailable|organization .* not found' snyk-code.log; then
             outcome="skip"
             reason="platform-or-access-rejection"
           fi
@@ -273,7 +273,7 @@ jobs:
           elif [ "$status" = "3" ]; then
             outcome="skip"
             reason="no-supported-projects"
-          elif grep -Eiq 'test limit|rate limit|too many requests|quota|payment required|unauthorized|forbidden|authentication failed|failed to authenticate|access denied|service unavailable|temporarily unavailable|organization .* not found' snyk-open-source.log; then
+          elif grep -Eiq 'test limit|rate limit|reached .* limit|too many requests|quota|payment required|unauthorized|forbidden|authentication failed|failed to authenticate|access denied|service unavailable|temporarily unavailable|organization .* not found' snyk-open-source.log; then
             outcome="skip"
             reason="platform-or-access-rejection"
           fi


### PR DESCRIPTION
## Summary
- Snyk Free plan의 월간 테스트 한도 초과 시 `"You have reached your monthly limit"` 에러가 기존 grep 패턴에 매칭되지 않아 PR을 블로킹하던 문제 수정
- classify step의 grep 패턴에 `reached .* limit` 추가하여 한도 초과를 `skip` (non-blocking)으로 처리
- Code Analysis, Open Source Dependencies 두 job 모두 동일하게 적용

## Test plan
- [ ] Snyk 한도 초과 상태에서 PR 생성 시 Snyk job이 skip으로 처리되는지 확인
- [ ] 실제 취약점 발견 시에는 여전히 PR 블로킹되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)