### PR TITLE
ci: disable Snyk from PR pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/codeql.yml
     secrets: inherit
 
-  snyk:
-    name: Snyk
-    uses: ./.github/workflows/snyk.yml
-    secrets: inherit
+  # snyk:
+  #   name: Snyk
+  #   uses: ./.github/workflows/snyk.yml
+  #   secrets: inherit


### PR DESCRIPTION
## Summary
- Snyk Free plan 테스트 한도 초과 및 기존 의존성 취약점으로 인해 무관한 PR이 계속 블로킹되는 문제
- Pipeline에서 Snyk job을 비활성화 (주석 처리)
- `snyk.yml` 자체는 유지 — 수동 실행(`workflow_dispatch`)과 주간 스케줄(`schedule`)은 계속 동작

## Test plan
- [ ] PR CI에서 Snyk check가 더 이상 실행되지 않는지 확인
- [ ] `snyk.yml`의 수동/스케줄 실행은 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)