### PR TITLE
fix: recompute channel server filters on subscriber removal

### DIFF
--- a/packages/sdk/js/packages/web/src/database-live.ts
+++ b/packages/sdk/js/packages/web/src/database-live.ts
@@ -88,16 +88,8 @@ export class DatabaseLiveClient implements IDatabaseLiveSubscriber {
     }
     this.subscriptions.get(channel)!.push(sub);
 
-    // Only set channel-level server filters when this is the first subscription
-    // for the channel. Subsequent subscriptions on the same channel should not
-    // overwrite the filters already sent to the server — that would silently
-    // break the earlier subscriber's expected filter set.
-    if (sub.serverFilters && sub.serverFilters.length > 0 && !this.channelFilters.has(channel)) {
-      this.channelFilters.set(channel, sub.serverFilters);
-    }
-    if (sub.serverOrFilters && sub.serverOrFilters.length > 0 && !this.channelOrFilters.has(channel)) {
-      this.channelOrFilters.set(channel, sub.serverOrFilters);
-    }
+    // Recompute merged channel filters from all active subscriptions.
+    this.recomputeChannelFilters(channel);
 
     this.connect(channel).catch(() => {
       // Errors surface through the normal auth/socket flow.
@@ -113,6 +105,10 @@ export class DatabaseLiveClient implements IDatabaseLiveSubscriber {
         this.channelFilters.delete(channel);
         this.channelOrFilters.delete(channel);
         this.sendUnsubscribe(channel);
+      } else {
+        // Recompute filters from remaining subscribers and re-send to server
+        this.recomputeChannelFilters(channel);
+        this.sendSubscribe(channel);
       }
     };
   }
@@ -374,6 +370,36 @@ export class DatabaseLiveClient implements IDatabaseLiveSubscriber {
       for (const handler of this.errorHandlers) {
         handler({ code: msg.code as string, message: msg.message as string });
       }
+    }
+  }
+
+  /**
+   * Recompute channel-level server filters by picking the filters from the
+   * first active subscription that has them.  When a subscriber is removed,
+   * this ensures the next subscriber's filters take effect instead of leaving
+   * stale filters from the removed subscriber.
+   */
+  private recomputeChannelFilters(channel: string): void {
+    const subs = this.subscriptions.get(channel);
+    if (!subs || subs.length === 0) {
+      this.channelFilters.delete(channel);
+      this.channelOrFilters.delete(channel);
+      return;
+    }
+
+    // Pick the first subscription that provides each filter type
+    const firstWithFilters = subs.find((s) => s.serverFilters && s.serverFilters.length > 0);
+    if (firstWithFilters?.serverFilters) {
+      this.channelFilters.set(channel, firstWithFilters.serverFilters);
+    } else {
+      this.channelFilters.delete(channel);
+    }
+
+    const firstWithOrFilters = subs.find((s) => s.serverOrFilters && s.serverOrFilters.length > 0);
+    if (firstWithOrFilters?.serverOrFilters) {
+      this.channelOrFilters.set(channel, firstWithOrFilters.serverOrFilters);
+    } else {
+      this.channelOrFilters.delete(channel);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the stale filter issue identified by Codex review on PR #13.

### Problem

PR #13 added a `!has(channel)` guard to prevent later subscriptions from overwriting earlier subscribers' server filters. However, this introduced a new edge case:

1. Subscriber A subscribes with **filter A** → `channelFilters[ch] = filterA` ✅
2. Subscriber B subscribes with **filter B** → skipped (channel already has filters) ✅
3. Subscriber A unsubscribes → channel still has subscribers, so filters are NOT cleared
4. **Bug:** Channel still uses **stale filter A**, but only subscriber B (expecting filter B) remains

### Fix

Added `recomputeChannelFilters(channel)` that picks the first active subscription's filters from the remaining subscribers list. Called on both:
- **Subscribe** — sets filters from the new subscription set
- **Unsubscribe** (when subscribers remain) — recomputes from remaining subscribers and re-sends to server via `sendSubscribe()`

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| A(filterA) → B(filterB) → A unsubs | Stale filterA used for B | filterB applied, re-sent to server |
| A(filterA) → B(no filter) → A unsubs | Stale filterA used | Filters cleared, re-sent to server |
| A(filterA) only → A unsubs | Channel removed ✅ | Channel removed ✅ (unchanged) |

## Test plan
- [ ] Subscribe A with filterA, subscribe B with filterB on same channel
- [ ] Unsubscribe A → verify server receives filterB via re-subscribe message
- [ ] Unsubscribe B → verify channel fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)