### PR TITLE
fix(server): remove host-based internal request trust

### DIFF
--- a/packages/server/src/__tests__/internal-request.test.ts
+++ b/packages/server/src/__tests__/internal-request.test.ts
@@ -21,16 +21,16 @@ function makeContext(
 }
 
 describe('internal request helpers', () => {
-  it('isTrustedInternalRequestUrl only trusts worker-internal hosts', () => {
-    expect(isTrustedInternalRequestUrl('http://internal/api/db/shared')).toBe(true);
-    expect(isTrustedInternalRequestUrl('http://do/internal/functions/reindex')).toBe(true);
+  it('isTrustedInternalRequestUrl never trusts hostnames', () => {
+    expect(isTrustedInternalRequestUrl('http://internal/api/db/shared')).toBe(false);
+    expect(isTrustedInternalRequestUrl('http://do/internal/functions/reindex')).toBe(false);
     expect(isTrustedInternalRequestUrl('http://localhost:8787/api/db/shared')).toBe(false);
     expect(isTrustedInternalRequestUrl('not-a-url')).toBe(false);
   });
 
-  it('isTrustedInternalContext accepts explicit internal flags or trusted internal hosts', () => {
+  it('isTrustedInternalContext only accepts explicit internal flags', () => {
     expect(isTrustedInternalContext(makeContext('http://localhost/api/db/shared', true))).toBe(true);
-    expect(isTrustedInternalContext(makeContext('http://do/api/db/shared'))).toBe(true);
+    expect(isTrustedInternalContext(makeContext('http://do/api/db/shared'))).toBe(false);
     expect(isTrustedInternalContext(makeContext('http://example.com/api/db/shared'))).toBe(false);
   });
 

--- a/packages/server/src/lib/internal-request.ts
+++ b/packages/server/src/lib/internal-request.ts
@@ -2,17 +2,14 @@ import type { Context } from 'hono';
 import type { HonoEnv } from './hono.js';
 import type { Env } from '../types.js';
 
-export function isTrustedInternalRequestUrl(url: string): boolean {
-  try {
-    const host = new URL(url).host;
-    return host === 'internal' || host === 'do';
-  } catch {
-    return false;
-  }
+export function isTrustedInternalRequestUrl(_url: string): boolean {
+  // Requests are only trusted when the runtime marks them internal via context.
+  // URL hosts (including 'do' / 'internal') can be spoofed in self-hosted or proxy setups.
+  return false;
 }
 
 export function isTrustedInternalContext(c: Pick<Context<HonoEnv>, 'get' | 'req'>): boolean {
-  return c.get('isInternalRequest' as never) === true || isTrustedInternalRequestUrl(c.req.url);
+  return c.get('isInternalRequest' as never) === true;
 }
 
 export function buildInternalHandlerContext(options: {


### PR DESCRIPTION
### Motivation
- A host-based internal trust check treated requests with hosts like `do` or `internal` as trusted, allowing an attacker to spoof the `Host` header and bypass service-key and table access rules for D1/Postgres handlers.

### Description
- Stop trusting URL hostnames by making `isTrustedInternalRequestUrl` always return `false` and adding a clarifying comment that hostnames can be spoofed.
- Make `isTrustedInternalContext` trust only the explicit `isInternalRequest` context flag set by the runtime, removing the URL-host fallback.
- Update the internal request unit tests to assert that `do`/`internal` hosts are no longer trusted and that only explicit internal flags are accepted.

### Testing
- Ran `pnpm -C packages/server test -- src/__tests__/internal-request.test.ts`, and the test file passed with 4 tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb5c716c0832795bf9bdb72afa61a)