### PR TITLE
Add SDK role contract gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -815,6 +815,167 @@ jobs:
               "$UNREAL_BUILD_DIR/unit_test"
               "$UNREAL_BUILD_DIR/e2e_test"'
 
+  # ─── Role Contract Catalog ──────────────────────────────────────────────────
+  sdk-role-contract-catalog:
+    name: SDK Role Contract Catalog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Verify role contract catalog
+        run: node ./scripts/sdk-role-contracts.mjs verify
+
+  # ─── Role Contract Gates ───────────────────────────────────────────────────
+  sdk-admin-contract:
+    name: SDK Admin Contract
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - sdk-role-contract-catalog
+      - sdk-go-e2e
+      - sdk-js-e2e
+      - sdk-python-e2e
+      - sdk-java-e2e
+      - sdk-kotlin-e2e
+      - sdk-dart-e2e
+      - sdk-rust-e2e
+      - sdk-csharp-e2e
+      - sdk-php-e2e
+      - sdk-elixir-e2e
+      - sdk-scala-e2e
+      - sdk-ruby-e2e
+    steps:
+      - name: Enforce admin contract coverage
+        run: |
+          results=(
+            "${{ needs.sdk-role-contract-catalog.result }}"
+            "${{ needs.sdk-go-e2e.result }}"
+            "${{ needs.sdk-js-e2e.result }}"
+            "${{ needs.sdk-python-e2e.result }}"
+            "${{ needs.sdk-java-e2e.result }}"
+            "${{ needs.sdk-kotlin-e2e.result }}"
+            "${{ needs.sdk-dart-e2e.result }}"
+            "${{ needs.sdk-rust-e2e.result }}"
+            "${{ needs.sdk-csharp-e2e.result }}"
+            "${{ needs.sdk-php-e2e.result }}"
+            "${{ needs.sdk-elixir-e2e.result }}"
+            "${{ needs.sdk-scala-e2e.result }}"
+            "${{ needs.sdk-ruby-e2e.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "admin contract dependency failed: $result"
+              exit 1
+            fi
+          done
+
+  sdk-core-contract:
+    name: SDK Core Contract
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - sdk-role-contract-catalog
+      - sdk-go-e2e
+      - sdk-js-e2e
+      - sdk-python-e2e
+      - sdk-java-e2e
+      - sdk-kotlin-e2e
+      - sdk-dart-e2e
+      - sdk-rust-e2e
+      - sdk-php-e2e
+      - sdk-swift-e2e
+      - sdk-cpp-e2e
+    steps:
+      - name: Enforce core contract coverage
+        run: |
+          results=(
+            "${{ needs.sdk-role-contract-catalog.result }}"
+            "${{ needs.sdk-go-e2e.result }}"
+            "${{ needs.sdk-js-e2e.result }}"
+            "${{ needs.sdk-python-e2e.result }}"
+            "${{ needs.sdk-java-e2e.result }}"
+            "${{ needs.sdk-kotlin-e2e.result }}"
+            "${{ needs.sdk-dart-e2e.result }}"
+            "${{ needs.sdk-rust-e2e.result }}"
+            "${{ needs.sdk-php-e2e.result }}"
+            "${{ needs.sdk-swift-e2e.result }}"
+            "${{ needs.sdk-cpp-e2e.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "core contract dependency failed: $result"
+              exit 1
+            fi
+          done
+
+  sdk-client-contract:
+    name: SDK Client Contract
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - sdk-role-contract-catalog
+      - sdk-js-e2e
+      - sdk-react-native-e2e
+      - sdk-java-e2e
+      - sdk-kotlin-e2e
+      - sdk-dart-e2e
+      - sdk-csharp-e2e
+      - sdk-swift-e2e
+      - sdk-cpp-e2e
+    steps:
+      - name: Enforce client contract coverage
+        run: |
+          results=(
+            "${{ needs.sdk-role-contract-catalog.result }}"
+            "${{ needs.sdk-js-e2e.result }}"
+            "${{ needs.sdk-react-native-e2e.result }}"
+            "${{ needs.sdk-java-e2e.result }}"
+            "${{ needs.sdk-kotlin-e2e.result }}"
+            "${{ needs.sdk-dart-e2e.result }}"
+            "${{ needs.sdk-csharp-e2e.result }}"
+            "${{ needs.sdk-swift-e2e.result }}"
+            "${{ needs.sdk-cpp-e2e.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "client contract dependency failed: $result"
+              exit 1
+            fi
+          done
+
+  sdk-client-auth-verify-contract:
+    name: SDK Client Auth Verify Contract
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - sdk-role-contract-catalog
+      - sdk-js-e2e
+      - sdk-react-native-e2e
+      - sdk-java-e2e
+      - sdk-kotlin-e2e
+      - sdk-dart-e2e
+      - sdk-swift-e2e
+    steps:
+      - name: Enforce client auth verify contract coverage
+        run: |
+          results=(
+            "${{ needs.sdk-role-contract-catalog.result }}"
+            "${{ needs.sdk-js-e2e.result }}"
+            "${{ needs.sdk-react-native-e2e.result }}"
+            "${{ needs.sdk-java-e2e.result }}"
+            "${{ needs.sdk-kotlin-e2e.result }}"
+            "${{ needs.sdk-dart-e2e.result }}"
+            "${{ needs.sdk-swift-e2e.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "client auth verify contract dependency failed: $result"
+              exit 1
+            fi
+          done
+
   # ─── Mutation Testing (PR only) ─────────────────────────────────────────────
   mutation-test:
     name: Mutation Testing
@@ -949,6 +1110,11 @@ jobs:
       - sdk-scala-e2e
       - sdk-ruby-e2e
       - sdk-cpp-e2e
+      - sdk-role-contract-catalog
+      - sdk-admin-contract
+      - sdk-core-contract
+      - sdk-client-contract
+      - sdk-client-auth-verify-contract
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -981,3 +1147,8 @@ jobs:
           echo "Scala E2E: ${{ needs.sdk-scala-e2e.result }}"
           echo "Ruby E2E: ${{ needs.sdk-ruby-e2e.result }}"
           echo "C++ E2E: ${{ needs.sdk-cpp-e2e.result }}"
+          echo "Role Contract Catalog: ${{ needs.sdk-role-contract-catalog.result }}"
+          echo "Admin Contract: ${{ needs.sdk-admin-contract.result }}"
+          echo "Core Contract: ${{ needs.sdk-core-contract.result }}"
+          echo "Client Contract: ${{ needs.sdk-client-contract.result }}"
+          echo "Client Auth Verify Contract: ${{ needs.sdk-client-auth-verify-contract.result }}"

--- a/packages/sdk/contracts/role-contracts.json
+++ b/packages/sdk/contracts/role-contracts.json
@@ -1,0 +1,93 @@
+{
+  "roles": {
+    "admin": {
+      "description": "Trusted server/admin SDK contract",
+      "checkpoints": [
+        "admin-auth",
+        "functions",
+        "database-crud",
+        "database-query",
+        "storage-basic",
+        "storage-advanced"
+      ],
+      "targets": [
+        { "sdk": "go", "job": "sdk-go-e2e", "mode": "adapted", "sources": ["packages/sdk/go/edgebase_e2e_test.go"] },
+        { "sdk": "js", "job": "sdk-js-e2e", "mode": "native", "sources": ["packages/sdk/js/packages/admin/test/e2e/admin.e2e.test.ts", "packages/sdk/js/packages/admin/test/e2e/property.e2e.test.ts"] },
+        { "sdk": "python", "job": "sdk-python-e2e", "mode": "native", "sources": ["packages/sdk/python/packages/admin/tests/test_admin_e2e.py"] },
+        { "sdk": "java", "job": "sdk-java-e2e", "mode": "native", "sources": ["packages/sdk/java/packages/admin/src/test/java/dev/edgebase/sdk/admin/AdminE2ETest.java"] },
+        { "sdk": "kotlin", "job": "sdk-kotlin-e2e", "mode": "native", "sources": ["packages/sdk/kotlin/admin/src/test/kotlin/dev/edgebase/sdk/admin/AdminEdgeBaseE2ETest.kt"] },
+        { "sdk": "dart", "job": "sdk-dart-e2e", "mode": "native", "sources": ["packages/sdk/dart/packages/admin/test/admin_e2e_test.dart"] },
+        { "sdk": "rust", "job": "sdk-rust-e2e", "mode": "adapted", "sources": ["packages/sdk/rust/tests/e2e.rs"] },
+        { "sdk": "csharp", "job": "sdk-csharp-e2e", "mode": "native", "sources": ["packages/sdk/csharp/packages/admin/tests/AdminE2ETests.cs"] },
+        { "sdk": "php", "job": "sdk-php-e2e", "mode": "native", "sources": ["packages/sdk/php/packages/admin/tests/e2e/AdminClientE2ETest.php"] },
+        { "sdk": "elixir", "job": "sdk-elixir-e2e", "mode": "native", "sources": ["packages/sdk/elixir/packages/admin/test/admin_e2e_test.exs"] },
+        { "sdk": "scala", "job": "sdk-scala-e2e", "mode": "native", "sources": ["packages/sdk/scala/packages/admin/src/test/scala/dev/edgebase/sdk/scala/admin/AdminEdgeBaseE2ETest.scala"] },
+        { "sdk": "ruby", "job": "sdk-ruby-e2e", "mode": "native", "sources": ["packages/sdk/ruby/packages/admin/test/test_admin_e2e.rb"] }
+      ]
+    },
+    "core": {
+      "description": "Common core SDK contract",
+      "checkpoints": [
+        "database-crud",
+        "database-query",
+        "batch",
+        "upsert",
+        "field-ops",
+        "storage-basic",
+        "storage-advanced",
+        "error-handling"
+      ],
+      "targets": [
+        { "sdk": "go", "job": "sdk-go-e2e", "mode": "adapted", "sources": ["packages/sdk/go/edgebase_e2e_test.go"] },
+        { "sdk": "js", "job": "sdk-js-e2e", "mode": "native", "sources": ["packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts"] },
+        { "sdk": "python", "job": "sdk-python-e2e", "mode": "native", "sources": ["packages/sdk/python/packages/core/tests/test_core_e2e.py"] },
+        { "sdk": "java", "job": "sdk-java-e2e", "mode": "native", "sources": ["packages/sdk/java/packages/core/src/test/java/dev/edgebase/sdk/core/CoreE2ETest.java"] },
+        { "sdk": "kotlin", "job": "sdk-kotlin-e2e", "mode": "native", "sources": ["packages/sdk/kotlin/core/src/androidUnitTest/kotlin/io/edgebase/sdk/EdgeBaseE2ETest.kt"] },
+        { "sdk": "dart", "job": "sdk-dart-e2e", "mode": "native", "sources": ["packages/sdk/dart/packages/core/test/core_e2e_test.dart"] },
+        { "sdk": "rust", "job": "sdk-rust-e2e", "mode": "adapted", "sources": ["packages/sdk/rust/tests/e2e.rs"] },
+        { "sdk": "php", "job": "sdk-php-e2e", "mode": "native", "sources": ["packages/sdk/php/packages/core/tests/e2e/CoreCrudE2ETest.php", "packages/sdk/php/packages/core/tests/e2e/CoreStorageE2ETest.php"] },
+        { "sdk": "swift", "job": "sdk-swift-e2e", "mode": "native", "sources": ["packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift"] },
+        { "sdk": "cpp", "job": "sdk-cpp-e2e", "mode": "native", "sources": ["packages/sdk/cpp/packages/core/tests/e2e_tests.cpp"] }
+      ]
+    },
+    "client": {
+      "description": "Client runtime SDK contract excluding browser lifecycle specifics",
+      "checkpoints": [
+        "auth-basic",
+        "database-crud",
+        "database-query",
+        "storage-basic",
+        "functions-invoke"
+      ],
+      "targets": [
+        { "sdk": "js", "job": "sdk-js-e2e", "mode": "native", "sources": ["packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts"] },
+        { "sdk": "react-native", "job": "sdk-react-native-e2e", "mode": "native", "sources": ["packages/sdk/react-native/test/e2e/rn.e2e.test.ts"] },
+        { "sdk": "java", "job": "sdk-java-e2e", "mode": "native", "sources": ["packages/sdk/java/packages/android/src/test/java/dev/edgebase/sdk/client/AndroidE2ETest.java"] },
+        { "sdk": "kotlin", "job": "sdk-kotlin-e2e", "mode": "native", "sources": ["packages/sdk/kotlin/client/src/androidUnitTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseE2ETest.kt"] },
+        { "sdk": "dart", "job": "sdk-dart-e2e", "mode": "native", "sources": ["packages/sdk/dart/packages/flutter/test/flutter_e2e_test.dart"] },
+        { "sdk": "csharp", "job": "sdk-csharp-e2e", "mode": "native", "sources": ["packages/sdk/csharp/packages/unity/tests/UnityE2ETests.cs"] },
+        { "sdk": "swift", "job": "sdk-swift-e2e", "mode": "native", "sources": ["packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift"] },
+        { "sdk": "cpp", "job": "sdk-cpp-e2e", "mode": "native", "sources": ["packages/sdk/cpp/packages/unreal/tests/e2e_tests.cpp"] }
+      ]
+    },
+    "client-auth-verify": {
+      "description": "Client auth verification loop contract",
+      "checkpoints": [
+        "magic-link",
+        "email-otp",
+        "phone-otp",
+        "password-reset",
+        "email-verify",
+        "email-change"
+      ],
+      "targets": [
+        { "sdk": "js", "job": "sdk-js-e2e", "mode": "native", "sources": ["packages/sdk/js/test/web.e2e.test.ts"] },
+        { "sdk": "react-native", "job": "sdk-react-native-e2e", "mode": "native", "sources": ["packages/sdk/react-native/test/e2e/rn.e2e.test.ts"] },
+        { "sdk": "java", "job": "sdk-java-e2e", "mode": "native", "sources": ["packages/sdk/java/packages/android/src/test/java/dev/edgebase/sdk/client/AndroidE2ETest.java"] },
+        { "sdk": "kotlin", "job": "sdk-kotlin-e2e", "mode": "native", "sources": ["packages/sdk/kotlin/client/src/jvmTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseJvmAuthE2ETest.kt", "packages/sdk/kotlin/client/src/androidUnitTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseE2ETest.kt"] },
+        { "sdk": "dart", "job": "sdk-dart-e2e", "mode": "native", "sources": ["packages/sdk/dart/packages/flutter/test/flutter_e2e_test.dart"] },
+        { "sdk": "swift", "job": "sdk-swift-e2e", "mode": "native", "sources": ["packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift"] }
+      ]
+    }
+  }
+}

--- a/scripts/sdk-role-contracts.mjs
+++ b/scripts/sdk-role-contracts.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
+const catalogPath = path.join(repoRoot, 'packages/sdk/contracts/role-contracts.json');
+const workflowPath = path.join(repoRoot, '.github/workflows/test.yml');
+
+const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+const workflowText = fs.readFileSync(workflowPath, 'utf8');
+
+const discovery = {
+  admin: [
+    { sdk: 'go', sources: ['packages/sdk/go/edgebase_e2e_test.go'] },
+    { sdk: 'js', sources: ['packages/sdk/js/packages/admin/test/e2e/admin.e2e.test.ts'] },
+    { sdk: 'python', sources: ['packages/sdk/python/packages/admin/tests/test_admin_e2e.py'] },
+    { sdk: 'java', sources: ['packages/sdk/java/packages/admin/src/test/java/dev/edgebase/sdk/admin/AdminE2ETest.java'] },
+    { sdk: 'kotlin', sources: ['packages/sdk/kotlin/admin/src/test/kotlin/dev/edgebase/sdk/admin/AdminEdgeBaseE2ETest.kt'] },
+    { sdk: 'dart', sources: ['packages/sdk/dart/packages/admin/test/admin_e2e_test.dart'] },
+    { sdk: 'rust', sources: ['packages/sdk/rust/tests/e2e.rs'] },
+    { sdk: 'csharp', sources: ['packages/sdk/csharp/packages/admin/tests/AdminE2ETests.cs'] },
+    { sdk: 'php', sources: ['packages/sdk/php/packages/admin/tests/e2e/AdminClientE2ETest.php'] },
+    { sdk: 'elixir', sources: ['packages/sdk/elixir/packages/admin/test/admin_e2e_test.exs'] },
+    { sdk: 'scala', sources: ['packages/sdk/scala/packages/admin/src/test/scala/dev/edgebase/sdk/scala/admin/AdminEdgeBaseE2ETest.scala'] },
+    { sdk: 'ruby', sources: ['packages/sdk/ruby/packages/admin/test/test_admin_e2e.rb'] }
+  ],
+  core: [
+    { sdk: 'go', sources: ['packages/sdk/go/edgebase_e2e_test.go'] },
+    { sdk: 'js', sources: ['packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts'] },
+    { sdk: 'python', sources: ['packages/sdk/python/packages/core/tests/test_core_e2e.py'] },
+    { sdk: 'java', sources: ['packages/sdk/java/packages/core/src/test/java/dev/edgebase/sdk/core/CoreE2ETest.java'] },
+    { sdk: 'kotlin', sources: ['packages/sdk/kotlin/core/src/androidUnitTest/kotlin/io/edgebase/sdk/EdgeBaseE2ETest.kt'] },
+    { sdk: 'dart', sources: ['packages/sdk/dart/packages/core/test/core_e2e_test.dart'] },
+    { sdk: 'rust', sources: ['packages/sdk/rust/tests/e2e.rs'] },
+    { sdk: 'php', sources: ['packages/sdk/php/packages/core/tests/e2e/CoreCrudE2ETest.php'] },
+    { sdk: 'swift', sources: ['packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift'] },
+    { sdk: 'cpp', sources: ['packages/sdk/cpp/packages/core/tests/e2e_tests.cpp'] }
+  ],
+  client: [
+    { sdk: 'js', sources: ['packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts'] },
+    { sdk: 'react-native', sources: ['packages/sdk/react-native/test/e2e/rn.e2e.test.ts'] },
+    { sdk: 'java', sources: ['packages/sdk/java/packages/android/src/test/java/dev/edgebase/sdk/client/AndroidE2ETest.java'] },
+    { sdk: 'kotlin', sources: ['packages/sdk/kotlin/client/src/androidUnitTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseE2ETest.kt'] },
+    { sdk: 'dart', sources: ['packages/sdk/dart/packages/flutter/test/flutter_e2e_test.dart'] },
+    { sdk: 'csharp', sources: ['packages/sdk/csharp/packages/unity/tests/UnityE2ETests.cs'] },
+    { sdk: 'swift', sources: ['packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift'] },
+    { sdk: 'cpp', sources: ['packages/sdk/cpp/packages/unreal/tests/e2e_tests.cpp'] }
+  ],
+  'client-auth-verify': [
+    { sdk: 'js', sources: ['packages/sdk/js/test/web.e2e.test.ts'] },
+    { sdk: 'react-native', sources: ['packages/sdk/react-native/test/e2e/rn.e2e.test.ts'] },
+    { sdk: 'java', sources: ['packages/sdk/java/packages/android/src/test/java/dev/edgebase/sdk/client/AndroidE2ETest.java'] },
+    { sdk: 'kotlin', sources: ['packages/sdk/kotlin/client/src/jvmTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseJvmAuthE2ETest.kt'] },
+    { sdk: 'dart', sources: ['packages/sdk/dart/packages/flutter/test/flutter_e2e_test.dart'] },
+    { sdk: 'swift', sources: ['packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift'] }
+  ]
+};
+
+function relExists(relPath) {
+  return fs.existsSync(path.join(repoRoot, relPath));
+}
+
+function discoverRoleTargets(role) {
+  return (discovery[role] ?? [])
+    .filter(entry => entry.sources.every(relExists))
+    .map(entry => entry.sdk)
+    .sort();
+}
+
+function getCatalogTargets(role) {
+  return (catalog.roles?.[role]?.targets ?? []).map(target => target.sdk).sort();
+}
+
+function ensureWorkflowJob(jobName) {
+  const pattern = new RegExp(`^\\s{2}${jobName}:\\s*$`, 'm');
+  return pattern.test(workflowText);
+}
+
+function verifyRole(role) {
+  const declared = catalog.roles?.[role];
+  if (!declared) {
+    throw new Error(`Unknown role '${role}' in catalog.`);
+  }
+
+  const discoveredTargets = discoverRoleTargets(role);
+  const catalogTargets = getCatalogTargets(role);
+
+  if (JSON.stringify(discoveredTargets) !== JSON.stringify(catalogTargets)) {
+    throw new Error(
+      [
+        `Role '${role}' target drift detected.`,
+        `  discovered: ${discoveredTargets.join(', ') || '(none)'}`,
+        `  catalog:    ${catalogTargets.join(', ') || '(none)'}`
+      ].join('\n')
+    );
+  }
+
+  for (const target of declared.targets) {
+    if (!ensureWorkflowJob(target.job)) {
+      throw new Error(`Role '${role}' target '${target.sdk}' references missing workflow job '${target.job}'.`);
+    }
+    for (const source of target.sources) {
+      if (!relExists(source)) {
+        throw new Error(`Role '${role}' target '${target.sdk}' references missing source '${source}'.`);
+      }
+    }
+  }
+}
+
+function printSummary() {
+  for (const [role, spec] of Object.entries(catalog.roles)) {
+    const targets = spec.targets.map(target => `${target.sdk}:${target.mode}`).join(', ');
+    console.log(`${role}: ${targets}`);
+  }
+}
+
+const [, , command = 'verify', roleArg] = process.argv;
+
+if (command === 'summary') {
+  printSummary();
+  process.exit(0);
+}
+
+if (command === 'verify' && roleArg) {
+  verifyRole(roleArg);
+  console.log(`verified role '${roleArg}'`);
+  process.exit(0);
+}
+
+if (command === 'verify') {
+  for (const role of Object.keys(catalog.roles)) {
+    verifyRole(role);
+  }
+  printSummary();
+  process.exit(0);
+}
+
+console.error(`Unknown command '${command}'. Use 'verify' or 'summary'.`);
+process.exit(1);


### PR DESCRIPTION
This ports the non-overlapping role-contract follow-up onto main after #18 merged.

Included:
- role contract catalog for admin/core/client/client-auth-verify
- verification script for role coverage drift
- workflow gates that aggregate existing SDK E2E jobs by role

This replaces the earlier stacked-only follow-up so main can receive the role-contract checks directly.