### PR TITLE
Add checkpoint evidence to SDK role contracts

### DIFF
--- a/packages/sdk/contracts/role-contracts.json
+++ b/packages/sdk/contracts/role-contracts.json
@@ -23,7 +23,83 @@
         { "sdk": "elixir", "job": "sdk-elixir-e2e", "mode": "native", "sources": ["packages/sdk/elixir/packages/admin/test/admin_e2e_test.exs"] },
         { "sdk": "scala", "job": "sdk-scala-e2e", "mode": "native", "sources": ["packages/sdk/scala/packages/admin/src/test/scala/dev/edgebase/sdk/scala/admin/AdminEdgeBaseE2ETest.scala"] },
         { "sdk": "ruby", "job": "sdk-ruby-e2e", "mode": "native", "sources": ["packages/sdk/ruby/packages/admin/test/test_admin_e2e.rb"] }
-      ]
+      ],
+      "evidence": {
+        "admin-auth": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/admin/test/e2e/admin.e2e.test.ts",
+              "pattern": "it('createUser → id 반환'"
+            },
+            {
+              "sdk": "php",
+              "source": "packages/sdk/php/packages/admin/tests/e2e/AdminClientE2ETest.php",
+              "pattern": "public function test_admin_auth_delete_user_and_verify(): void"
+            }
+          ]
+        },
+        "functions": {
+          "entries": [],
+          "reason": "Public repo does not yet contain service-backed admin SDK function invocation tests in the role target suites."
+        },
+        "database-crud": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/admin/test/e2e/admin.e2e.test.ts",
+              "pattern": "it('insert → id'"
+            },
+            {
+              "sdk": "php",
+              "source": "packages/sdk/php/packages/admin/tests/e2e/AdminClientE2ETest.php",
+              "pattern": "public function test_db_delete_then_get_throws(): void"
+            }
+          ]
+        },
+        "database-query": {
+          "entries": [
+            {
+              "sdk": "php",
+              "source": "packages/sdk/php/packages/admin/tests/e2e/AdminClientE2ETest.php",
+              "pattern": "public function test_where_filter_finds_record(): void"
+            },
+            {
+              "sdk": "php",
+              "source": "packages/sdk/php/packages/admin/tests/e2e/AdminClientE2ETest.php",
+              "pattern": "public function test_order_by_limit(): void"
+            }
+          ]
+        },
+        "storage-basic": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/admin/test/e2e/admin.e2e.test.ts",
+              "pattern": "it('upload + getUrl'"
+            },
+            {
+              "sdk": "php",
+              "source": "packages/sdk/php/packages/admin/tests/e2e/AdminClientE2ETest.php",
+              "pattern": "public function test_storage_upload_and_download(): void"
+            }
+          ]
+        },
+        "storage-advanced": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/admin/test/e2e/admin.e2e.test.ts",
+              "pattern": "it('upload + signedUrl'"
+            },
+            {
+              "sdk": "rust",
+              "source": "packages/sdk/rust/tests/e2e.rs",
+              "pattern": "async fn e2e_56_storage_resumable_upload() {"
+            }
+          ]
+        }
+      }
     },
     "core": {
       "description": "Common core SDK contract",
@@ -48,7 +124,121 @@
         { "sdk": "php", "job": "sdk-php-e2e", "mode": "native", "sources": ["packages/sdk/php/packages/core/tests/e2e/CoreCrudE2ETest.php", "packages/sdk/php/packages/core/tests/e2e/CoreStorageE2ETest.php"] },
         { "sdk": "swift", "job": "sdk-swift-e2e", "mode": "native", "sources": ["packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift"] },
         { "sdk": "cpp", "job": "sdk-cpp-e2e", "mode": "native", "sources": ["packages/sdk/cpp/packages/core/tests/e2e_tests.cpp"] }
-      ]
+      ],
+      "evidence": {
+        "database-crud": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('insert → id 반환'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift",
+              "pattern": "func test_crud_chain_insert_read_update_delete() async throws {"
+            }
+          ]
+        },
+        "database-query": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('where == 필터 → 해당 레코드만 반환'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift",
+              "pattern": "func test_orderBy_desc() async throws {"
+            }
+          ]
+        },
+        "batch": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('insertMany → N개 반환'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift",
+              "pattern": "func test_insertMany() async throws {"
+            }
+          ]
+        },
+        "upsert": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('upsert 새 레코드 → action === \"inserted\"'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift",
+              "pattern": "func test_upsert_updates_existing() async throws {"
+            }
+          ]
+        },
+        "field-ops": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('increment → viewCount 증가'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift",
+              "pattern": "func test_deleteField() async throws {"
+            }
+          ]
+        },
+        "storage-basic": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('upload + download text file'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift",
+              "pattern": "func test_upload_and_download() async throws {"
+            }
+          ]
+        },
+        "storage-advanced": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('initiateResumableUpload + getUploadParts + resumeUpload complete successfully'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/core/Tests/CoreE2ETests.swift",
+              "pattern": "func test_signed_upload_url() async throws {"
+            }
+          ]
+        },
+        "error-handling": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/core/test/e2e/core.e2e.test.ts",
+              "pattern": "it('getOne 없는 id → 에러'"
+            },
+            {
+              "sdk": "python",
+              "source": "packages/sdk/python/packages/core/tests/test_core_e2e.py",
+              "pattern": "def test_error_has_status_code(self, admin):"
+            }
+          ]
+        }
+      }
     },
     "client": {
       "description": "Client runtime SDK contract excluding browser lifecycle specifics",
@@ -68,7 +258,69 @@
         { "sdk": "csharp", "job": "sdk-csharp-e2e", "mode": "native", "sources": ["packages/sdk/csharp/packages/unity/tests/UnityE2ETests.cs"] },
         { "sdk": "swift", "job": "sdk-swift-e2e", "mode": "native", "sources": ["packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift"] },
         { "sdk": "cpp", "job": "sdk-cpp-e2e", "mode": "native", "sources": ["packages/sdk/cpp/packages/unreal/tests/e2e_tests.cpp"] }
-      ]
+      ],
+      "evidence": {
+        "auth-basic": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts",
+              "pattern": "it('signup → accessToken + user.id'"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift",
+              "pattern": "func test_signUp_signIn_signOut_chain() async throws {"
+            }
+          ]
+        },
+        "database-crud": {
+          "entries": [
+            {
+              "sdk": "csharp",
+              "source": "packages/sdk/csharp/packages/unity/tests/UnityE2ETests.cs",
+              "pattern": "public async Task Sequential_operations_insert_read_update_delete()"
+            },
+            {
+              "sdk": "dart",
+              "source": "packages/sdk/dart/packages/flutter/test/flutter_e2e_test.dart",
+              "pattern": "test('create → getOne → same record', () async {"
+            }
+          ]
+        },
+        "database-query": {
+          "entries": [
+            {
+              "sdk": "dart",
+              "source": "packages/sdk/dart/packages/flutter/test/flutter_e2e_test.dart",
+              "pattern": "test('where filter → only matching records', () async {"
+            },
+            {
+              "sdk": "swift",
+              "source": "packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift",
+              "pattern": "func test_orderBy_and_limit() async throws {"
+            }
+          ]
+        },
+        "storage-basic": {
+          "entries": [
+            {
+              "sdk": "java",
+              "source": "packages/sdk/java/packages/android/src/test/java/dev/edgebase/sdk/client/AndroidE2ETest.java",
+              "pattern": "void test_storage_upload_download_roundtrip_with_auth() {"
+            },
+            {
+              "sdk": "csharp",
+              "source": "packages/sdk/csharp/packages/unity/tests/UnityE2ETests.cs",
+              "pattern": "public async Task Storage_upload_and_download_with_auth()"
+            }
+          ]
+        },
+        "functions-invoke": {
+          "entries": [],
+          "reason": "Public repo does not yet contain service-backed client SDK function invocation tests in the role target suites."
+        }
+      }
     },
     "client-auth-verify": {
       "description": "Client auth verification loop contract",
@@ -81,13 +333,69 @@
         "email-change"
       ],
       "targets": [
-        { "sdk": "js", "job": "sdk-js-e2e", "mode": "native", "sources": ["packages/sdk/js/test/web.e2e.test.ts"] },
+        { "sdk": "js", "job": "sdk-js-e2e", "mode": "native", "sources": ["packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts"] },
         { "sdk": "react-native", "job": "sdk-react-native-e2e", "mode": "native", "sources": ["packages/sdk/react-native/test/e2e/rn.e2e.test.ts"] },
         { "sdk": "java", "job": "sdk-java-e2e", "mode": "native", "sources": ["packages/sdk/java/packages/android/src/test/java/dev/edgebase/sdk/client/AndroidE2ETest.java"] },
         { "sdk": "kotlin", "job": "sdk-kotlin-e2e", "mode": "native", "sources": ["packages/sdk/kotlin/client/src/jvmTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseJvmAuthE2ETest.kt", "packages/sdk/kotlin/client/src/androidUnitTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseE2ETest.kt"] },
         { "sdk": "dart", "job": "sdk-dart-e2e", "mode": "native", "sources": ["packages/sdk/dart/packages/flutter/test/flutter_e2e_test.dart"] },
         { "sdk": "swift", "job": "sdk-swift-e2e", "mode": "native", "sources": ["packages/sdk/swift/packages/ios/Tests/IosE2ETests.swift"] }
-      ]
+      ],
+      "evidence": {
+        "magic-link": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts",
+              "pattern": "it('magic link request + verifyMagicLink → currentUser populated', async () => {"
+            }
+          ]
+        },
+        "email-otp": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts",
+              "pattern": "it('email OTP request + verifyEmailOtp → session created', async () => {"
+            }
+          ]
+        },
+        "phone-otp": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts",
+              "pattern": "it('phone OTP request + verifyPhone → verified phone session', async () => {"
+            }
+          ]
+        },
+        "password-reset": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts",
+              "pattern": "it('requestPasswordReset + resetPassword → new password sign-in works', async () => {"
+            }
+          ]
+        },
+        "email-verify": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts",
+              "pattern": "it('requestEmailVerification + verifyEmail → me reflects verified user', async () => {"
+            }
+          ]
+        },
+        "email-change": {
+          "entries": [
+            {
+              "sdk": "js",
+              "source": "packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts",
+              "pattern": "it('changeEmail + verifyEmailChange → new email sign-in works', async () => {"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/scripts/sdk-role-contracts.mjs
+++ b/scripts/sdk-role-contracts.mjs
@@ -9,6 +9,7 @@ const workflowPath = path.join(repoRoot, '.github/workflows/test.yml');
 
 const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
 const workflowText = fs.readFileSync(workflowPath, 'utf8');
+const sourceCache = new Map();
 
 const discovery = {
   admin: [
@@ -48,7 +49,7 @@ const discovery = {
     { sdk: 'cpp', sources: ['packages/sdk/cpp/packages/unreal/tests/e2e_tests.cpp'] }
   ],
   'client-auth-verify': [
-    { sdk: 'js', sources: ['packages/sdk/js/test/web.e2e.test.ts'] },
+    { sdk: 'js', sources: ['packages/sdk/js/packages/web/test/e2e/web.e2e.test.ts'] },
     { sdk: 'react-native', sources: ['packages/sdk/react-native/test/e2e/rn.e2e.test.ts'] },
     { sdk: 'java', sources: ['packages/sdk/java/packages/android/src/test/java/dev/edgebase/sdk/client/AndroidE2ETest.java'] },
     { sdk: 'kotlin', sources: ['packages/sdk/kotlin/client/src/jvmTest/kotlin/dev/edgebase/sdk/client/ClientEdgeBaseJvmAuthE2ETest.kt'] },
@@ -61,20 +62,100 @@ function relExists(relPath) {
   return fs.existsSync(path.join(repoRoot, relPath));
 }
 
+function readRel(relPath) {
+  if (!sourceCache.has(relPath)) {
+    sourceCache.set(relPath, fs.readFileSync(path.join(repoRoot, relPath), 'utf8'));
+  }
+  return sourceCache.get(relPath);
+}
+
+function sortStrings(values) {
+  return [...values].sort();
+}
+
 function discoverRoleTargets(role) {
   return (discovery[role] ?? [])
-    .filter(entry => entry.sources.every(relExists))
-    .map(entry => entry.sdk)
+    .filter((entry) => entry.sources.every(relExists))
+    .map((entry) => entry.sdk)
     .sort();
 }
 
 function getCatalogTargets(role) {
-  return (catalog.roles?.[role]?.targets ?? []).map(target => target.sdk).sort();
+  return (catalog.roles?.[role]?.targets ?? []).map((target) => target.sdk).sort();
 }
 
 function ensureWorkflowJob(jobName) {
   const pattern = new RegExp(`^\\s{2}${jobName}:\\s*$`, 'm');
   return pattern.test(workflowText);
+}
+
+function getRoleTargetMap(role) {
+  const declared = catalog.roles?.[role];
+  return new Map((declared?.targets ?? []).map((target) => [target.sdk, target]));
+}
+
+function normalizeEvidence(role, checkpoint, rawEvidence, targetMap) {
+  if (!rawEvidence || typeof rawEvidence !== 'object' || Array.isArray(rawEvidence)) {
+    throw new Error(`Role '${role}' checkpoint '${checkpoint}' must define an evidence object.`);
+  }
+
+  const entries = rawEvidence.entries;
+  if (!Array.isArray(entries)) {
+    throw new Error(`Role '${role}' checkpoint '${checkpoint}' must define an entries array.`);
+  }
+
+  const reason = rawEvidence.reason;
+  if (entries.length === 0 && typeof reason !== 'string') {
+    throw new Error(
+      `Role '${role}' checkpoint '${checkpoint}' has no evidence entries and must declare a reason.`
+    );
+  }
+
+  const coveredTargets = new Set();
+  for (const [index, entry] of entries.entries()) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Role '${role}' checkpoint '${checkpoint}' entry #${index + 1} must be an object.`);
+    }
+
+    const { sdk, source, pattern } = entry;
+    if (typeof sdk !== 'string' || !targetMap.has(sdk)) {
+      throw new Error(`Role '${role}' checkpoint '${checkpoint}' entry #${index + 1} references unknown sdk '${sdk}'.`);
+    }
+    if (typeof source !== 'string') {
+      throw new Error(`Role '${role}' checkpoint '${checkpoint}' entry #${index + 1} must define a source.`);
+    }
+    if (!relExists(source)) {
+      throw new Error(`Role '${role}' checkpoint '${checkpoint}' entry #${index + 1} references missing source '${source}'.`);
+    }
+
+    const target = targetMap.get(sdk);
+    if (!target.sources.includes(source)) {
+      throw new Error(
+        `Role '${role}' checkpoint '${checkpoint}' entry #${index + 1} uses source '${source}' outside target '${sdk}' sources.`
+      );
+    }
+
+    if (typeof pattern !== 'string' || pattern.length === 0) {
+      throw new Error(`Role '${role}' checkpoint '${checkpoint}' entry #${index + 1} must define a non-empty pattern.`);
+    }
+    if (!readRel(source).includes(pattern)) {
+      throw new Error(
+        `Role '${role}' checkpoint '${checkpoint}' entry #${index + 1} pattern not found in '${source}': ${pattern}`
+      );
+    }
+
+    coveredTargets.add(sdk);
+  }
+
+  const missingTargets = sortStrings([...targetMap.keys()].filter((sdk) => !coveredTargets.has(sdk)));
+  const status = entries.length === 0 ? 'gap' : missingTargets.length === 0 ? 'covered' : 'partial';
+
+  return {
+    status,
+    reason,
+    coveredTargets: sortStrings(coveredTargets),
+    missingTargets
+  };
 }
 
 function verifyRole(role) {
@@ -106,33 +187,78 @@ function verifyRole(role) {
       }
     }
   }
+
+  const evidence = declared.evidence ?? {};
+  const checkpointSet = new Set(declared.checkpoints);
+
+  for (const checkpoint of declared.checkpoints) {
+    if (!(checkpoint in evidence)) {
+      throw new Error(`Role '${role}' checkpoint '${checkpoint}' is missing an evidence declaration.`);
+    }
+  }
+
+  for (const checkpoint of Object.keys(evidence)) {
+    if (!checkpointSet.has(checkpoint)) {
+      throw new Error(`Role '${role}' evidence declares unknown checkpoint '${checkpoint}'.`);
+    }
+  }
+
+  const targetMap = getRoleTargetMap(role);
+  const checkpoints = declared.checkpoints.map((checkpoint) => ({
+    checkpoint,
+    ...normalizeEvidence(role, checkpoint, evidence[checkpoint], targetMap)
+  }));
+
+  return {
+    role,
+    targets: declared.targets.map((target) => `${target.sdk}:${target.mode}`),
+    checkpoints
+  };
 }
 
-function printSummary() {
-  for (const [role, spec] of Object.entries(catalog.roles)) {
-    const targets = spec.targets.map(target => `${target.sdk}:${target.mode}`).join(', ');
-    console.log(`${role}: ${targets}`);
+function printSummary(results) {
+  for (const result of results) {
+    const counts = result.checkpoints.reduce(
+      (acc, checkpoint) => {
+        acc[checkpoint.status] += 1;
+        return acc;
+      },
+      { covered: 0, partial: 0, gap: 0 }
+    );
+
+    console.log(
+      `${result.role}: targets=${result.targets.join(', ')} | checkpoints covered=${counts.covered} partial=${counts.partial} gap=${counts.gap}`
+    );
+
+    for (const checkpoint of result.checkpoints) {
+      const coverage = checkpoint.coveredTargets.length > 0 ? checkpoint.coveredTargets.join(', ') : '(none)';
+      const missing = checkpoint.missingTargets.length > 0 ? checkpoint.missingTargets.join(', ') : '(none)';
+      const suffix = checkpoint.reason ? ` | reason: ${checkpoint.reason}` : '';
+      console.log(
+        `  - ${checkpoint.checkpoint}: ${checkpoint.status} | covered=${coverage} | missing=${missing}${suffix}`
+      );
+    }
   }
 }
 
 const [, , command = 'verify', roleArg] = process.argv;
 
 if (command === 'summary') {
-  printSummary();
+  const roles = roleArg ? [roleArg] : Object.keys(catalog.roles);
+  const results = roles.map((role) => verifyRole(role));
+  printSummary(results);
   process.exit(0);
 }
 
 if (command === 'verify' && roleArg) {
-  verifyRole(roleArg);
-  console.log(`verified role '${roleArg}'`);
+  const result = verifyRole(roleArg);
+  printSummary([result]);
   process.exit(0);
 }
 
 if (command === 'verify') {
-  for (const role of Object.keys(catalog.roles)) {
-    verifyRole(role);
-  }
-  printSummary();
+  const results = Object.keys(catalog.roles).map((role) => verifyRole(role));
+  printSummary(results);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- add checkpoint-to-test evidence declarations to the SDK role contract catalog
- verify each declared evidence pattern exists in the referenced role target test file
- print per-checkpoint covered/partial/gap status so CI exposes parity gaps instead of only listing targets

## Validation
- node --check scripts/sdk-role-contracts.mjs
- node ./scripts/sdk-role-contracts.mjs verify
- ruby -e 'require "json"; JSON.parse(File.read("packages/sdk/contracts/role-contracts.json")); puts "json ok"'