### PR TITLE
Document CodeQL policy for stacked PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@
 - [ ] I updated docs, examples, or generated outputs if needed.
 - [ ] I kept the change focused and scoped to a clear problem.
 - [ ] I considered compatibility, migration, or rollout impact.
+- [ ] If this PR does not target `main` or `develop`, I understand CodeQL may appear as `neutral` here and must be green on the final PR to `main`/`develop`.
 
 ## Breaking Changes
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,9 @@ name: Pipeline
 
 on:
   pull_request:
+    # Intentionally limited to final PRs targeting protected branches.
+    # Stacked PRs against intermediate codex/* branches may therefore show
+    # GitHub's CodeQL code-scanning check as neutral/no-result, which is expected.
     types: [opened, synchronize, reopened]
     branches: [main, develop]
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ edgebase/
 2. Update documentation if your change affects the public API
 3. Write a clear PR description explaining **what** and **why**
 4. One feature per PR — keep changes focused
+5. If you use stacked PRs, treat CodeQL as required on the final PR targeting `main` or `develop`. Intermediate PRs against temporary branches may show GitHub's CodeQL code-scanning check as `neutral` because the main pipeline does not run there.
 
 ## Commit Messages
 


### PR DESCRIPTION
## Summary
- document that the main pipeline only runs for PRs targeting `main` or `develop`
- clarify that stacked PRs may show CodeQL as `neutral` and this is expected
- require CodeQL to be green on the final PR to `main`/`develop`

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pipeline.yml"); puts "yaml ok"'