### PR TITLE
fix(server): add direct D1 path for admin.auth.createUser()

### DIFF
--- a/packages/server/src/lib/functions.ts
+++ b/packages/server/src/lib/functions.ts
@@ -1096,7 +1096,8 @@ export function buildAdminAuthContext(options: AdminAuthOptions): AdminAuthConte
       // Direct D1 path — works without service key (same as updateUser/deleteUser)
       if (d1Database) {
         // Input validation (mirrors routes/admin-auth.ts guards)
-        if (!data.email || !data.password) throw new Error('Email and password are required.');
+        if (!data.email || typeof data.email !== 'string') throw new Error('Email and password are required.');
+        if (!data.password || typeof data.password !== 'string') throw new Error('Email and password are required.');
         const email = data.email.trim().toLowerCase();
         if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
           throw new Error('Invalid email format.');


### PR DESCRIPTION
## Summary

`admin.auth.createUser()` in server functions was the **only** admin auth method missing a direct D1 path. All other methods (`getUser`, `listUsers`, `updateUser`, `deleteUser`, `setCustomClaims`) already work directly against `AUTH_DB` D1 without requiring a service key.

This caused `createUser()` to silently fail in local dev (`edgebase dev`) when no service keys are configured — which is the default for most apps.

## Root cause

```typescript
// Before: createUser only had the HTTP relay path
async createUser(data) {
  if (workerUrl && serviceKey) {  // ← serviceKey is undefined without config
    // HTTP relay (only path)
  }
  throw new Error('not available');  // ← always reached in local dev
}

// After: direct D1 path added (same pattern as updateUser/deleteUser)
async createUser(data) {
  if (d1Database) {
    // Direct D1 — no service key needed
  }
  if (workerUrl && serviceKey) {
    // HTTP relay fallback
  }
  throw new Error('not available');
}
```

## Changes

| File | Change |
|------|--------|
| `packages/server/src/lib/functions.ts` | Add direct D1 path using existing `createManagedAdminUser()`, `hashPassword()`, `generateId()` |

## How it was found

Testing the Facebook example app with 3 simultaneous players in local dev. The `seed-demo` server function called `admin.auth.createUser()` to create demo accounts, but it returned `authUsers: 0` because the call silently failed (caught by empty `catch {}`). Had to work around it by calling the public `/api/auth/signup` endpoint instead.

## Test plan

- [x] Verify `createManagedAdminUser` handles email index, `_users_public` projection, and error cleanup (existing tests in `admin-user-management.test.ts`)
- [ ] `edgebase dev` → server function with `admin.auth.createUser()` → user created without service key config
- [ ] Existing HTTP relay path still works when service key is configured