### PR TITLE
perf(server): route ctx table().sql through direct executor

### DIFF
--- a/packages/sdk/js/packages/core/src/index.ts
+++ b/packages/sdk/js/packages/core/src/index.ts
@@ -13,7 +13,7 @@ export { createSubscription } from './types.js';
 export { HttpClient, type HttpClientOptions } from './http.js';
 
 // Table
-export { TableRef, DocRef, DbRef, OrBuilder, type ListResult, type TableSnapshot, type FilterTuple, type UpsertResult, type BatchByFilterResult } from './table.js';
+export { TableRef, DocRef, DbRef, OrBuilder, type ListResult, type TableSnapshot, type FilterTuple, type UpsertResult, type BatchByFilterResult, type TableSqlExecutor } from './table.js';
 
 // Storage
 export { StorageClient, StorageBucket, ResumableUploadError, type UploadTask, type FileInfo, type FileMetadata, type FileListResult, type UploadOptions, type UploadProgress, type DownloadOptions, type SignedUrlOptions, type SignedUrlResult, type SignedUploadUrlOptions, type SignedUploadUrlResult, type DeleteManyResult, type ListOptions, type StringFormat, type UploadPartInfo, type UploadPartsResult } from './storage.js';

--- a/packages/sdk/js/packages/core/src/table.ts
+++ b/packages/sdk/js/packages/core/src/table.ts
@@ -62,6 +62,13 @@ export interface BatchByFilterResult {
   errors: Array<{ chunkIndex: number; chunkSize: number; error: EdgeBaseError }>;
 }
 
+export type TableSqlExecutor = (
+  namespace: string,
+  instanceId: string | undefined,
+  query: string,
+  params?: unknown[],
+) => Promise<unknown[]>;
+
 // ─── Database Live Channel Builder ───
 
 /**
@@ -352,11 +359,22 @@ export class TableRef<T = Record<string, unknown>> {
      * TODO: remove once admin core is wired.
      */
     private _httpClient?: HttpClient,
+    /** Optional direct SQL executor used by trusted server contexts. */
+    private _sqlExecutor?: TableSqlExecutor,
   ) {}
 
   /** Create a clone with current state (for immutable chaining) */
   private clone(): TableRef<T> {
-    const ref = new TableRef<T>(this.core, this.name, this.databaseLiveClient, this.filterMatchFn, this.namespace, this.instanceId, this._httpClient);
+    const ref = new TableRef<T>(
+      this.core,
+      this.name,
+      this.databaseLiveClient,
+      this.filterMatchFn,
+      this.namespace,
+      this.instanceId,
+      this._httpClient,
+      this._sqlExecutor,
+    );
     ref.filters = [...this.filters];
     ref.orFilters = [...this.orFilters];
     ref.sorts = [...this.sorts];
@@ -801,9 +819,6 @@ export class TableRef<T = Record<string, unknown>> {
    * `;
    */
   async sql(strings: TemplateStringsArray, ...values: unknown[]): Promise<unknown[]> {
-    if (!this._httpClient) {
-      throw new EdgeBaseError(500, 'sql() requires HttpClient (admin-only method). Use context.admin.db(...).table(...).sql`...`');
-    }
     // Build parameterized query from tagged template — each ${} becomes ?
     let query = '';
     const params: unknown[] = [];
@@ -813,6 +828,12 @@ export class TableRef<T = Record<string, unknown>> {
         query += '?';
         params.push(values[i]);
       }
+    }
+    if (this._sqlExecutor) {
+      return this._sqlExecutor(this.namespace, this.instanceId, query.trim(), params);
+    }
+    if (!this._httpClient) {
+      throw new EdgeBaseError(500, 'sql() requires HttpClient or direct SQL executor (admin-only method).');
     }
     // §11: body uses { namespace, id, sql, params }
     // /api/sql is admin-only, tagged 'admin', lives in admin core — not client core.
@@ -852,6 +873,8 @@ export class DbRef {
      * TODO: remove once admin core is wired.
      */
     private _httpClient?: HttpClient,
+    /** Optional direct SQL executor used by trusted server contexts. */
+    private _sqlExecutor?: TableSqlExecutor,
   ) {}
 
   /**
@@ -869,6 +892,7 @@ export class DbRef {
       this.namespace,
       this.instanceId,
       this._httpClient,
+      this._sqlExecutor,
     );
   }
 }

--- a/packages/sdk/js/packages/core/test/unit/core.unit.test.ts
+++ b/packages/sdk/js/packages/core/test/unit/core.unit.test.ts
@@ -214,6 +214,60 @@ describe('TableRef', () => {
     expect(result.items[0]?.id).toBe('post-1');
     expect(result.total).toBe(1);
   });
+
+  it('sql tagged template prefers the direct SQL executor when provided', async () => {
+    const sqlExecutor = vi.fn().mockResolvedValue([{ total: 3 }]);
+    const httpClient = { post: vi.fn() } as any;
+    const table = new TableRef(
+      {} as any,
+      'posts',
+      undefined,
+      undefined,
+      'shared',
+      undefined,
+      httpClient,
+      sqlExecutor,
+    );
+
+    const rows = await table.sql`SELECT COUNT(*) AS total FROM posts WHERE status = ${'published'}`;
+
+    expect(rows).toEqual([{ total: 3 }]);
+    expect(sqlExecutor).toHaveBeenCalledWith(
+      'shared',
+      undefined,
+      'SELECT COUNT(*) AS total FROM posts WHERE status = ?',
+      ['published'],
+    );
+    expect(httpClient.post).not.toHaveBeenCalled();
+  });
+
+  it('sql tagged template falls back to HttpClient when no direct SQL executor is provided', async () => {
+    const httpClient = {
+      post: vi.fn().mockResolvedValue([{ total: 1 }]),
+    } as any;
+    const table = new TableRef(
+      {} as any,
+      'posts',
+      undefined,
+      undefined,
+      'shared',
+      undefined,
+      httpClient,
+    );
+
+    const rows = await table.sql`SELECT COUNT(*) AS total FROM posts WHERE id = ${'post-1'}`;
+
+    expect(rows).toEqual([{ total: 1 }]);
+    expect(httpClient.post).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        namespace: 'shared',
+        id: undefined,
+        sql: 'SELECT COUNT(*) AS total FROM posts WHERE id = ?',
+        params: ['post-1'],
+      },
+    );
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/packages/server/src/__tests__/functions-context.test.ts
+++ b/packages/server/src/__tests__/functions-context.test.ts
@@ -213,6 +213,72 @@ describe('buildFunctionContext admin.db', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('routes admin.db(...).table(...).sql tagged templates through the direct SQL executor when env is available', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stub = {
+      fetch: vi.fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({
+            needsCreate: true,
+            namespace: 'workspace',
+            id: 'ws-1',
+          }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({
+            rows: [{ total: 5 }],
+            items: [{ total: 5 }],
+            results: [{ total: 5 }],
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+    };
+    const databaseNamespace = {
+      idFromName: vi.fn().mockReturnValue('do-id'),
+      get: vi.fn().mockReturnValue(stub),
+    } as unknown as DurableObjectNamespace;
+
+    const ctx = buildFunctionContext({
+      request: new Request('http://localhost/api/functions/feed-summary'),
+      auth: null,
+      databaseNamespace,
+      authNamespace: {} as DurableObjectNamespace,
+      d1Database: {} as D1Database,
+      config: {
+        databases: {
+          workspace: {
+            tables: {
+              members: { schema: { userId: { type: 'string' } } },
+            },
+          },
+        },
+      },
+      env: {} as never,
+      workerUrl: 'http://localhost:8787',
+      serviceKey: 'sk-test',
+    });
+
+    const rows = await ctx.admin.db('workspace', 'ws-1').table('members').sql`
+      SELECT COUNT(*) AS total FROM members WHERE role = ${'owner'}
+    `;
+
+    expect(rows).toEqual([{ total: 5 }]);
+    expect(stub.fetch).toHaveBeenCalledTimes(2);
+    const firstRequest = stub.fetch.mock.calls[0]?.[0] as Request;
+    await expect(firstRequest.json()).resolves.toEqual({
+      query: 'SELECT COUNT(*) AS total FROM members WHERE role = ?',
+      params: ['owner'],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('routes admin.kv through the configured KV binding when env is available', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/server/src/lib/functions.ts
+++ b/packages/server/src/lib/functions.ts
@@ -799,8 +799,8 @@ export async function executeSqlWithDirectD1Access(
  * direct D1/PG/DO access (no HTTP round-trip).
  */
 export function buildAdminDbProxy(options: BuildAdminDbProxyOptions): FunctionAdminContext['db'] {
-  // Create HttpClient for sql() tagged template support on TableRef.
-  // Only available when workerUrl is set (routes through /api/sql endpoint).
+  // Create HttpClient fallback for sql() tagged template support on TableRef.
+  // Trusted server contexts also receive a direct SQL executor below.
   let httpClient: HttpClient | undefined;
   if (options.workerUrl) {
     httpClient = new HttpClient({
@@ -809,6 +809,24 @@ export function buildAdminDbProxy(options: BuildAdminDbProxyOptions): FunctionAd
       contextManager: new ContextManager(),
     });
   }
+  const sqlExecutor = (
+    namespace: string,
+    id: string | undefined,
+    query: string,
+    params?: unknown[],
+  ) => executeSqlWithDirectD1Access(
+    {
+      env: options.env,
+      config: options.config,
+      databaseNamespace: options.databaseNamespace,
+      workerUrl: options.workerUrl,
+      serviceKey: options.serviceKey,
+    },
+    namespace,
+    id,
+    query,
+    params,
+  );
 
   return (namespace: string, id?: string): DbRef => {
     // Create a per-DbRef transport with explicit dbContext so that
@@ -831,6 +849,7 @@ export function buildAdminDbProxy(options: BuildAdminDbProxyOptions): FunctionAd
       undefined,   // databaseLiveClient — not available server-side
       undefined,   // filterMatchFn
       httpClient,  // enables table().sql`...` tagged template
+      sqlExecutor,
     );
   };
 }


### PR DESCRIPTION
## Summary
- route `ctx.admin.db(...).table(...).sql` through the direct SQL executor in trusted server contexts
- keep the existing HttpClient `/api/sql` fallback for external admin runtimes
- add unit coverage for both the direct executor path and the fallback path

## Why
`ctx.admin.db(...).table(...).sql` currently goes through `/api/sql` even inside server contexts, while regular `db/table` CRUD already uses the internal direct transport. This change makes tagged SQL behave consistently with the rest of the server-side admin DB proxy.

## Test plan
- `pnpm --dir packages/sdk/js/packages/core test`
- `pnpm --dir packages/sdk/js/packages/core build`
- `pnpm --dir packages/server test`