### PR TITLE
test: use sqlite durable object migrations in wrangler fixtures

### DIFF
--- a/packages/server/wrangler.bench.toml
+++ b/packages/server/wrangler.bench.toml
@@ -14,8 +14,7 @@ bindings = [
 
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["DatabaseDO", "AuthDO"]
-new_classes = ["DatabaseLiveDO", "RoomsDO"]
+new_sqlite_classes = ["DatabaseDO", "AuthDO", "DatabaseLiveDO", "RoomsDO"]
 
 [[r2_buckets]]
 binding = "STORAGE"

--- a/packages/server/wrangler.test.toml
+++ b/packages/server/wrangler.test.toml
@@ -17,8 +17,7 @@ bindings = [
 
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["DatabaseDO", "AuthDO", "LogsDO"]
-new_classes = ["RoomsDO", "DatabaseLiveDO"]
+new_sqlite_classes = ["DatabaseDO", "AuthDO", "LogsDO", "DatabaseLiveDO", "RoomsDO"]
 
 # ─── R2 (local emulation) ───
 [[r2_buckets]]


### PR DESCRIPTION
## Summary

- Update the test and benchmark Wrangler fixtures to create `DatabaseLiveDO` and `RoomsDO` with `new_sqlite_classes` instead of `new_classes`.
- Keep the fixture config aligned with the rest of the project examples and with Cloudflare's current Durable Object guidance.

## Why

- Workers Free only supports SQLite-backed Durable Objects.
- `DatabaseLiveDO` and `RoomsDO` use the WebSocket hibernation APIs, which Cloudflare documents with `new_sqlite_classes`.
- This avoids drift between the local test/bench fixtures and the runtime expectations of these Durable Object classes.

## Testing

- Config-only change.
- I did not run the full suite yet.

## Checklist

- [ ] I ran the relevant tests and checks for this change.
- [ ] I updated docs, examples, or generated outputs if needed.
- [x] I kept the change focused and scoped to a clear problem.
- [x] I considered compatibility, migration, or rollout impact.
- [ ] If this PR does not target `main` or `develop`, I understand CodeQL may appear as `neutral` here and must be green on the final PR to `main`/`develop`.

## Breaking Changes

- [ ] This change is breaking.
