### PR TITLE
skills: add EdgeBase AI guardrails

### DIFF
--- a/skills/edgebase/SKILL.md
+++ b/skills/edgebase/SKILL.md
@@ -57,15 +57,20 @@ Do not read every reference file by default. First inspect the repo, runtime, an
 
 - Do not assume old auth response shapes from memory or stale examples. Before destructuring auth results, verify the selected package reference and the current repo types.
 - Do not treat a recent `npm view` result or your own memory as definitive during a fresh release window. If version reports conflict, compare npm registry dist-tags, installed dependency trees, and every manifest/lockfile that can affect the running app, including nested `edgebase/` projects, before changing versions or filing regressions.
+- Do not stop at declared CLI versions when functions are involved. Verify the installed CLI-transitive runtime packages too, plus the actual `npx edgebase --version`, before saying the function runtime is aligned.
 - Do not assume a public option is functional just because it exists in a constructor type. If the reference does not describe behavior, treat the option as inert until repo code proves otherwise.
 - Do not infer type-safe table models from `edgebase typegen` unless the selected package reference shows the exact integration pattern. Prefer explicit table generics or generated types already used by the repo.
+- Do not infer an SDK or runtime bug from a README snippet alone. When examples, types, and observed behavior disagree, check the published typings and implementation before escalating.
 - Do not read `table.where(...).onSnapshot(...)` as a server-filtered live query by default. Verify whether the selected SDK surface still needs `{ serverFilter: true }` before claiming the subscription is narrow or cheap.
 - Do not mix callback contracts between `table.onSnapshot(...)` and `table.doc(id).onSnapshot(...)`. Verify whether the current surface emits a table snapshot or a `(data, change)` pair before wiring handlers.
+- Do not assume the function-runtime DB surface differs from the client query-builder surface because of stale memory or old examples. Verify the current `ctx.db(...)` and `ctx.admin.db(...)` contract before rewriting working code or filing an API-parity bug.
 - Do not assume a flaky multi-client flow is an SDK/server bug before ruling out app-layer caching, polling, optimistic reconciliation, or search/discoverability code. Separate platform behavior from app behavior before escalating.
 - Do not bolt full-table reloads on top of snapshot payloads unless the reference or repo proves it is necessary. The extra round trips can create fake performance regressions and hide the original ordering problem.
 - Do not assume Room member state automatically solves lobby/list occupancy. If a UI needs room data outside a joined room, verify the current SDK surface for a queryable occupancy primitive before inventing or implying one.
 - Do not treat media transport as guaranteed. Before calling `transport.connect()` or promising camera/mic UX, verify the selected reference, current environment, and fallback path for unsupported or unconfigured runtimes.
 - Do not assume auth persistence is automatically isolated between colocated apps, localhost ports, or embedded previews. If multiple EdgeBase clients share one origin, verify storage keys, BroadcastChannel names, and SSR cookies will not collide.
+- Do not assume a raw `fetch()` to EdgeBase auth or function routes carries the same auth context as SDK helpers. Verify which token, cookie, or header actually authenticates the request in the current origin and port setup before blaming the backend.
+- Do not hardcode localhost origins for server self-calls, cleanup hooks, or seed flows when the runtime can move across ports or environments. Derive the worker origin from the request or environment and verify both request-driven and scheduled paths.
 - Do not treat `EBADENGINE` as proof that the runtime is either broken or supported. Separate metadata warnings from actual runtime verification, and report both honestly.
 - Do not assume `edgebase dev --port X` means the live process is still serving `X`. For fixed-port workflows, re-check the real bound port and a health path after restarts.
 - Do not trust an occupied port or a dev-process PID as proof that the app is healthy. Verify a real page response and at least one expected asset or manifest path before reusing the process for QA.
@@ -84,13 +89,15 @@ Do not read every reference file by default. First inspect the repo, runtime, an
 - For SDK, CLI, or version-upgrade work:
   verify the latest published version first, align every relevant package and lockfile including nested `edgebase/` projects, then run the smallest meaningful compile/build/test loop before declaring success.
 - For fresh package releases or conflicting version reports:
-  verify npm registry dist-tags, installed `node_modules` package versions, and both top-level and nested manifests before saying the repo is current.
+  verify npm registry dist-tags, installed `node_modules` package versions, top-level and nested manifests, and any CLI-transitive runtime packages before saying the repo is current.
 - For auth changes:
   test the real sign-in path used by the app, confirm the returned shape matches the selected reference, and verify persistence/isolation when multiple clients or colocated apps are in play before wiring cookies, tokens, or redirects.
+- For raw auth or function `fetch()` calls:
+  prove the authenticated user context on the server with an auth-dependent read or write, not just an HTTP 200 or a local optimistic state change.
 - For realtime changes:
   verify both the callback shape and the server-vs-client filtering behavior from the selected reference before optimizing or claiming scale characteristics.
 - For suspected SDK/server bugs:
-  build the smallest repro you can and write down which app-layer causes you already ruled out. Do not escalate a platform bug on confidence alone.
+  build the smallest repro you can, write down which app-layer causes you already ruled out, and confirm the current published surface before calling the mismatch an upstream bug. Do not escalate a platform bug on confidence alone.
 - For Room-based features:
   separate in-room state from out-of-room discovery. Test lobby occupancy, first-join behavior, and post-leave cleanup from a client that is not already inside the room.
 - For optimistic realtime UI:
@@ -111,6 +118,8 @@ Do not read every reference file by default. First inspect the repo, runtime, an
   if you had to create an ad-hoc script to prove a fix, move the durable part into repo-local regression coverage before you leave the task.
 - For multi-app or nested-project work:
   verify the top-level app, the nested `edgebase/` project, and their dev ports/scripts agree before declaring the setup reproducible.
+- For function-triggered internal workflows:
+  verify both direct request paths and scheduler or self-call paths, and make sure origin derivation, auth headers, and fallback behavior do not depend on a stale localhost assumption.
 - For runtime or toolchain validation:
   when the package declares a Node range, run at least one meaningful check on that supported runtime or clearly state that your validation was done under an unsupported version.
 


### PR DESCRIPTION
## Summary

This PR strengthens the source `skills/edgebase/SKILL.md` in the monorepo with a more practical anti-self-deception checklist for AI coding agents working on real EdgeBase apps.

The goal is not to reteach EdgeBase. The goal is to help the next agent avoid believable-but-wrong conclusions such as:

- thinking the declared CLI version means the function runtime is also aligned
- mistaking a raw `fetch()` success or optimistic UI flip for a real authenticated server-backed success
- inferring an SDK bug from a README snippet without checking the published typings or implementation
- assuming `ctx.db(...)` or `ctx.admin.db(...)` differs from the client query-builder surface because of stale memory or old examples
- hardcoding localhost origins for self-calls, cleanup hooks, or seed flows and then misdiagnosing the fallout as a platform issue
- blaming EdgeBase before ruling out app-layer state, cache, reconciliation, search, or QA-harness mistakes

In other words, this is AI-to-AI operational guidance: the kind of lessons you only get after hardening a real app, fixing a few regressions, correcting your own wrong assumptions, and deliberately separating platform truth from app truth.

## Why

The common failure mode here is not lack of effort. It is false certainty.

An agent can do a lot of work, sound convincing, and still be wrong about where truth actually lives:

- in the selected package reference vs stale memory
- in the installed dependency tree vs a single registry lookup
- in the actual function runtime package vs a declared CLI devDependency
- in a real authenticated server write vs a local optimistic state flip or HTTP 200
- in the current published surface vs a README snippet or older example
- in a healthy page response vs an occupied port or leftover PID
- in a canonical record ID vs a title, sort position, or stale URL captured earlier
- in durable repo-local regression coverage vs a one-off script that disappears with the chat session

Recent example-app work made these failure modes concrete enough that the skill should warn about them explicitly.

## What changed in the skill

### Common Footguns

Expanded the guardrails around:

- checking CLI-transitive runtime packages and `npx edgebase --version`, not just declared manifests
- treating README examples as hints until typings and implementation agree with them
- verifying whether function-context DB helpers actually differ before calling it an API-parity problem
- proving what auth context a raw `fetch()` is really using instead of assuming SDK-like behavior
- deriving worker origins for self-calls instead of hardcoding localhost assumptions
- continuing to guard against optimistic-UI false positives, stale routes, stale entity IDs, no-op controls, and misleading local-runtime warnings

### Validation

Added stronger guidance to:

- verify top-level, nested, installed, and transitive runtime versions before declaring an upgrade complete
- prove server-side auth context for raw auth/function `fetch()` calls with an auth-dependent read or write
- confirm the current published surface before escalating a mismatch as an upstream SDK/server bug
- validate both direct request paths and scheduler or self-call paths for internal workflows
- keep the existing emphasis on fixed-port health checks, canonical IDs, cross-client verification, optimistic rollback, and durable repo-local regression coverage

## Concrete motivation from recent work

A few recent example-app findings are exactly the sort of thing this skill is meant to protect against:

- Real JS apps can still hit typing erosion at query/list boundaries, so an agent should not over-promise typegen or SDK inference. See [edge-base/edgebase-project#20](https://github.com/edge-base/edgebase-project/issues/20).
- `edgebase dev` can emit local Durable Object warnings that look scarier than the actual observed behavior, so agents should separate noisy diagnostics from reproducible platform bugs. See [edge-base/edgebase-project#21](https://github.com/edge-base/edgebase-project/issues/21).
- `table.where(...).onSnapshot(...)` can look narrower than it really is, so agents should verify the current filtering behavior and callback contract from the published surface before making performance claims or wiring handlers. See [edge-base/edgebase-project#22](https://github.com/edge-base/edgebase-project/issues/22) and [#23](https://github.com/edge-base/edgebase-project/issues/23).
- Fixed-port workflows are only trustworthy if the agent verifies the actual serving process and health path after restarts, not just a bound port. See [edge-base/edgebase-project#18](https://github.com/edge-base/edgebase-project/issues/18) and [#19](https://github.com/edge-base/edgebase-project/issues/19).
- Example-app QA is much more trustworthy when ad-hoc validation gets promoted into reusable in-repo coverage instead of living only in temporary scripts.

## Design goal

This is intentionally written like a compact “do not fool yourself” checklist for other AI agents.

The emphasis is operational honesty:

- know which source of truth you are trusting
- know whether you observed UI state, app logic, test-harness behavior, or an actual EdgeBase guarantee
- know what you verified, what you inferred, and what still needs a second client, refresh, rollback path, or server-side check to prove
- leave behind rerunnable verification, not just a confident narrative

## Why this belongs in the source skill

The public `agent-skills` repo is generated from this monorepo, so the durable fix belongs in the source skill here.

## Validation

- `node tools/agent-skill-gen/verify.mjs`
