### PR TITLE
Align README and docs messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">EdgeBase</h1>
 
 <p align="center">
-  <b>100x cheaper than Firebase. ~0ms cold starts. Near-unlimited scale.</b><br>
-  Open-source edge-native BaaS that runs on Edge, Docker, and Node.js
+  Open-source edge-native BaaS built on Workers, Durable Objects, D1, and R2.<br>
+  <b>No egress or bandwidth fees. ~0ms cold starts. Scale-out by design.</b>
 </p>
 
 <p align="center">
@@ -17,8 +17,8 @@
 </p>
 
 <p align="center">
-  Auth · Database · Realtime · Storage · Functions · Admin UI<br>
-  Same app across local, self-hosted, and global edge
+  Run the same app locally, self-host with Docker, or deploy to Cloudflare's global edge.<br>
+  Auth · Database · Realtime · Storage · Functions · Admin UI
 </p>
 
 ---

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -68,14 +68,19 @@ See the [Self-Hosting Guide](/docs/getting-started/self-hosting) for setup instr
 | Self-hosting simplicity                | `docker run` vs 10+ container docker-compose.                            |
 | Multiplayer / real-time games          | Built-in Room with server-authoritative state — no separate game server. |
 
+**PostgreSQL-specific notes:**
+
+| Scenario                      | EdgeBase approach                                      | Notes                                                                                                         |
+| ----------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Geospatial queries (PostGIS)  | Switch the block to `provider: 'postgres'`             | EdgeBase's PostgreSQL provider gives you Postgres, but PostGIS setup still requires manual configuration.    |
+| Existing PostgreSQL ecosystem | Use PostgreSQL-backed blocks for shared/static data    | Covers most general Postgres use cases; some extension-heavy workflows may still require direct setup.       |
+| Multi-statement transactions  | Plan around EdgeBase's `transactionSync()` model       | The app-facing DB API does not expose raw `BEGIN`/`COMMIT`, even when the backing provider is PostgreSQL.   |
+
 **Other platforms may be a better fit for:**
 
-| Scenario                       | Better Choice                 | Why                                                                                                                   |
-| ------------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Geospatial queries (PostGIS)   | Supabase                      | SQLite lacks PostGIS extensions. EdgeBase's PostgreSQL provider gives you Postgres, but PostGIS setup still requires manual configuration. |
-| Existing PostgreSQL ecosystem  | Supabase                      | pg_vector, foreign data wrappers, etc. — though EdgeBase's PostgreSQL provider covers most general Postgres use cases.            |
-| Zero-config prototype in 1 day | Firebase                      | Unmatched onboarding speed and documentation ecosystem.                                                               |
-| Multi-statement transactions   | Supabase                      | EdgeBase supports `transactionSync()` only — no `BEGIN`/`COMMIT`.                                                     |
+| Scenario                       | Better Choice | Why                                                     |
+| ------------------------------ | ------------- | ------------------------------------------------------- |
+| Zero-config prototype in 1 day | Firebase      | Unmatched onboarding speed and documentation ecosystem. |
 
 :::tip PostgreSQL Provider
 For shared/static DB blocks that need cross-tenant analytics, unlimited storage, or full PostgreSQL capabilities, switch to `provider: 'postgres'` and add a connection-string env key such as `DB_POSTGRES_ANALYTICS_URL`. No SDK or application code changes are required. The optional Neon helper can provision or reconnect that env value for you.

--- a/docs/docs/getting-started/deployment.md
+++ b/docs/docs/getting-started/deployment.md
@@ -8,7 +8,7 @@ EdgeBase supports three deployment modes. The same code runs identically in all 
 
 ## Cloud Edge
 
-Global serverless deployment on 330+ edge locations.
+Global serverless deployment on 300+ edge locations.
 
 ```bash
 npx edgebase deploy

--- a/docs/docs/getting-started/introduction.md
+++ b/docs/docs/getting-started/introduction.md
@@ -5,7 +5,7 @@ slug: /getting-started
 
 # Introduction
 
-**EdgeBase** is the first Backend-as-a-Service built entirely on serverless edge infrastructure. Auth, Database, Room, Storage, Functions — the entire stack runs natively on [workerd](https://github.com/cloudflare/workerd), Cloudflare's open-source runtime. This means automatic horizontal scaling with zero configuration, near-zero cost at any scale, and physical data isolation by default. It runs everywhere — on the cloud edge, in a Docker container, or directly on any Node.js server. No vendor lock-in, MIT licensed.
+**EdgeBase** is an open-source edge-native BaaS built on Workers, Durable Objects, D1, and R2. Auth, Database, Realtime, Storage, and Functions share one serverless edge architecture, while shared blocks can switch to PostgreSQL when you need it. Run the same app locally on Node.js, self-host with Docker, or deploy globally on Cloudflare's edge. No vendor lock-in, MIT licensed.
 
 ## Why EdgeBase?
 
@@ -20,7 +20,7 @@ slug: /getting-started
 | **Edge Deploy** | No | No | No | **Yes** |
 | **Open Source** | No | Yes (AGPL) | Yes (MIT) | **Yes (MIT)** |
 
-### Scales Automatically
+### Scale-Out by Design
 
 Every other BaaS funnels traffic through a single database. When your app grows, you need replicas, connection pooling, and sharding. EdgeBase gives each user/tenant its own Durable Object with embedded SQLite — more users means more instances, not more load on a bottleneck. **10 users and 10 million users run the same code and config.**
 
@@ -36,13 +36,13 @@ Deploy your backend in whichever way suits your project:
 
 Same code, same behavior across all three modes. No vendor lock-in.
 
-### No Cost Explosion
+### Costs Scale with Compute, Not Users
 
-Start free, scale without fear. No per-user auth charges (Firebase charges $4,415/mo at 1M MAU). No egress fees (R2 = $0). Idle instances cost $0 (DO Hibernation). Deploy core services to Cloudflare's edge on the Free plan, then scale up with the $5/month paid plan (account-level — covers unlimited projects). Optional products like R2 still need a one-time billing setup before first use. Or self-host for free.
+Start free, scale without fear. No per-user auth charges. No egress or bandwidth fees on the Cloudflare edge stack EdgeBase builds on. Idle instances cost $0 through DO hibernation. Deploy core services to Cloudflare's edge on the Free plan, then scale up with the $5/month paid plan (account-level — covers unlimited projects). Optional products like R2 still need a one-time billing setup before first use. Or self-host for free.
 
-### 0ms Cold Start
+### ~0ms Cold Starts
 
-Built on workerd -- your API responds instantly with no containers to spin up.
+Built on [workerd](https://github.com/cloudflare/workerd), so requests hit V8 isolates instead of waiting for containers to boot.
 
 ### Fully Open Source
 

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -190,7 +190,7 @@ Start with Quickstart, move into the core products you need, and keep SDKs and C
 </div>
 
 <div className="docs-landing-card docs-landing-card--static">
-  <div className="docs-landing-card-title">~0ms Cold Start, 330+ Cities</div>
+  <div className="docs-landing-card-title">~0ms Cold Start, 300+ Cities</div>
   <p className="docs-landing-card-desc">
     V8 isolates pre-warmed at every Cloudflare edge location. No container boot, no runtime init.
   </p>

--- a/docs/docs/why-edgebase/cost-analysis.md
+++ b/docs/docs/why-edgebase/cost-analysis.md
@@ -176,14 +176,14 @@ EdgeBase achieves deployment flexibility because Cloudflare's `workerd` runtime 
 
 ## Trade-offs
 
-EdgeBase's architecture is not universally better. There are scenarios where other platforms excel:
+EdgeBase's architecture is not universally better. A few scenarios need more deliberate setup:
 
-| Scenario                      | Better Choice | Why                                                                                                                                        |
-| ----------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| PostGIS / geospatial queries  | Supabase      | SQLite lacks PostGIS extensions. EdgeBase's PostgreSQL provider gives you Postgres, but PostGIS setup still requires manual configuration. |
-| Zero-config prototype (1 day) | Firebase      | Unmatched onboarding speed and documentation                                                                                               |
-| Existing PostgreSQL ecosystem | Supabase      | pg_vector, PostGIS, foreign data wrappers, etc. — though EdgeBase's PostgreSQL provider covers most general Postgres use cases.            |
-| Multi-statement transactions  | Supabase      | EdgeBase supports `transactionSync()` only — no `BEGIN`/`COMMIT`                                                                           |
+| Scenario                      | EdgeBase note                                                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| PostGIS / geospatial queries  | Switch the block to `provider: 'postgres'`. EdgeBase gives you Postgres, but PostGIS setup is still manual.     |
+| Existing PostgreSQL ecosystem | PostgreSQL-backed blocks cover most general Postgres use cases, though some extension-heavy workflows need more direct setup. |
+| Multi-statement transactions  | The app-facing DB API exposes `transactionSync()` rather than raw `BEGIN`/`COMMIT`, even on PostgreSQL-backed blocks. |
+| Zero-config prototype (1 day) | Firebase still has the edge on onboarding speed and documentation.                                               |
 
 :::tip PostgreSQL Provider
 Cross-tenant analytics, complex SQL JOINs, and datasets exceeding 10 GB are all handled within EdgeBase by switching static DB blocks to `provider: 'postgres'` and supplying a connection-string env key. Dynamic multi-tenant blocks (workspace/user) each have a 10 GB limit per instance, which is rarely reached in practice. If you use Neon, the CLI and dev dashboard can provision that env key for you.

--- a/docs/docs/why-edgebase/overview.md
+++ b/docs/docs/why-edgebase/overview.md
@@ -7,13 +7,13 @@ sidebar_position: 0
 
 # Why EdgeBase?
 
-EdgeBase is the **first Backend-as-a-Service built entirely on serverless edge infrastructure**. Every other BaaS — Firebase, Supabase, Appwrite, PocketBase — runs on traditional server architecture: a central database, a container, or a single process. EdgeBase runs Auth, Database, Storage, and Functions natively on Cloudflare Workers and Durable Objects.
+EdgeBase is an **open-source edge-native BaaS built on Workers, Durable Objects, D1, and R2**. Instead of centering everything on a single app server and single database, EdgeBase composes distributed serverless primitives for auth, database, realtime, storage, and functions. Shared blocks can also switch to PostgreSQL when you need conventional Postgres semantics.
 
-This single architectural decision is why everything else is different.
+That architecture is why EdgeBase can pair no egress or bandwidth fees, ~0ms cold starts, and scale-out by design.
 
 ---
 
-## Zero Scaling Effort
+## Scale-Out by Design
 
 Traditional BaaS platforms funnel all traffic through a single database. When your app grows, you deal with connection pooling, read replicas, database sharding, and capacity planning. EdgeBase has none of this.
 
@@ -42,7 +42,7 @@ No shared locks. No connection pool limits. No contention.
 
 ---
 
-## No Cost Explosion
+## Costs Track Compute, Not Users
 
 The real fear for startups: start free, app goes viral, next month's bill is catastrophic. EdgeBase eliminates this structurally.
 
@@ -54,11 +54,11 @@ The real fear for startups: start free, app goes viral, next month's bill is cat
 | Idle instances                            | Server runs 24/7 | Server runs 24/7 | **$0**                        |
 | **Total (1M MAU social app, core stack)** | **$22,048/mo**   | **$14,297/mo**   | **~$149/mo**                  |
 
-**Why?** Because serverless edge architecture eliminates the cost structures that other platforms are built on:
+**Why?** Because the architecture changes which line items exist in the first place:
 
 - **Auth $0** — JWT verified locally (pure crypto), no session server. D1 included allowance (25B reads/month) handles all auth data. Outgrow D1? Switch to Neon PostgreSQL with one config change.
-- **Egress $0** — Cloudflare charges zero egress across the entire stack: R2 (Storage), D1 (Auth DB), Workers (compute), Durable Objects (database & database subscriptions), and WebSocket traffic. This is by design, not a promotional offer.
-- **Database Subscriptions ~300x cheaper** — WebSocket broadcast inside a DO. No per-recipient billing.
+- **No egress or bandwidth fees** — R2 serves files with $0 egress, and Workers/D1 do not add separate transfer or throughput billing. Realtime stays inside DO compute instead of creating a separate per-recipient bill.
+- **Database subscriptions stay inside compute** — WebSocket broadcast happens inside a DO, so the billing model is compute + ops rather than a separate per-recipient realtime product.
 - **Idle $0** — Durable Objects hibernate. No traffic = no cost.
 - **Cold start ~0ms** — V8 isolates boot in under a millisecond. No container spin-up, no runtime initialization. Your API responds instantly even after hours of inactivity.
 
@@ -68,21 +68,21 @@ That **~$149/mo** figure is the core social-app stack (auth + DB + storage + dat
 
 ---
 
-## One Command to Start, One Command to Deploy
+## Same App, Three Deploy Modes
 
 `workerd`, Cloudflare's edge runtime, is open source. The same code runs in development and production with zero changes.
 
 ```bash
 npx edgebase dev          # Start locally (like PocketBase)
-npx edgebase deploy       # Deploy to 330+ edge locations globally
+npx edgebase deploy       # Deploy to 300+ edge locations globally
 npx edgebase docker run   # Self-host in a single container
 ```
 
 |                 | PocketBase             | Supabase                        | **EdgeBase**             |
 | --------------- | ---------------------- | ------------------------------- | ------------------------ |
 | **Start**       | Single binary          | docker-compose (10+ containers) | **`npx edgebase dev`**   |
-| **Scale**       | Single process ceiling | Manual (replicas, pooling)      | **Automatic (infinite)** |
-| **Edge deploy** | No                     | No                              | **Yes (330+ cities)**    |
+| **Scale**       | Single process ceiling | Manual (replicas, pooling)      | **Scale-out by design**  |
+| **Edge deploy** | No                     | No                              | **Yes (300+ cities)**    |
 | **Cold start**  | ~0ms                   | ~500ms                          | **~0ms**                 |
 
 ---
@@ -175,7 +175,7 @@ Server route definition (Hono + Zod)
 |                        |     Firebase      |      Supabase       |      PocketBase      |       **EdgeBase**       |
 | ---------------------- | :---------------: | :-----------------: | :------------------: | :----------------------: |
 | **Architecture**       |    Central DB     |     Central DB      |    Single process    |   **Serverless edge**    |
-| **Scaling**            |      Manual       |  Manual (replicas)  | Single process limit | **Automatic (infinite)** |
+| **Scaling**            |      Manual       |  Manual (replicas)  | Single process limit | **Scale-out by design**  |
 | **Deploy**             |   Managed only    | Managed / Self-host |      Self-host       | **Edge / Docker / Node** |
 | **Database**           | Firestore (NoSQL) |     PostgreSQL      |        SQLite        | **SQLite + PostgreSQL**  |
 | **Auth cost** (1M MAU) |      $4,415       |       $2,925        |         Free         |         **Free**         |

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -26,9 +26,9 @@ const homeSdkItems = [
   { key: 'Elixir', label: 'Elixir' },
 ];
 const homeStats = [
-  { value: '148×', label: 'Cheaper', sub: 'vs Firebase at 1M MAU' },
-  { value: '~0ms', label: 'Cold Start', sub: '300+ edge locations' },
-  { value: '$0', label: 'Auth & Egress', sub: 'No MAU charges, ever' },
+  { value: '148×', label: 'Cheaper', sub: 'vs Firebase at 1M MAU scenario' },
+  { value: '~0ms', label: 'Cold Starts', sub: 'V8 isolates across 300+ cities' },
+  { value: '$0', label: 'Egress', sub: 'No egress or bandwidth fees' },
   {
     value: String(sdkLanguageCount),
     label: 'SDK Languages',
@@ -51,14 +51,14 @@ function HeroSection() {
     <section className="hero-section">
       <p className="hero-badge">Open Source · MIT License</p>
       <h1 className="hero-title">
-        100× cheaper than Firebase.
+        Open-source edge-native BaaS
         <br />
-        ~0ms cold starts at the edge.
+        built on Workers, Durable Objects, D1, and R2.
       </h1>
       <p className="hero-tagline">
-        Open-source edge-native BaaS for Database, Auth, Storage, Functions, Room, and Admin UI.
+        No egress or bandwidth fees. ~0ms cold starts. Scale-out by design.
         <br />
-        Same app, same behavior — local, self-hosted, or global edge.
+        Run the same app locally, self-host with Docker, or deploy to Cloudflare&apos;s global edge.
       </p>
       <div className="hero-code">
         <code>npm create edgebase@latest my-app</code>
@@ -119,10 +119,11 @@ function EntryPointsSection() {
 function CostSection() {
   return (
     <section className="comparison-section">
-      <h2>Why 100× Cheaper?</h2>
+      <h2>Why Lower Cost at Scale?</h2>
       <p className="section-subtitle">
-        Auth MAU billing and egress are the two biggest cost drivers at scale. EdgeBase removes
-        both, and database subscriptions stay inside DO compute instead of turning into a separate
+        Auth MAU billing and transfer charges are two of the biggest cost drivers at scale.
+        EdgeBase removes the first, avoids separate egress and bandwidth fees on the Cloudflare
+        edge stack it builds on, and keeps realtime inside DO compute instead of turning it into a
         per-recipient bill.
       </p>
       <div className="comparison-table-wrap">
@@ -210,9 +211,9 @@ function CostSection() {
 function SpeedSection() {
   return (
     <section className="comparison-section">
-      <h2>Why 100× Faster?</h2>
+      <h2>Why ~0ms Cold Starts?</h2>
       <p className="section-subtitle">
-        V8 isolates pre-warmed at 300+ edge locations worldwide. No container boot, no runtime init.
+        V8 isolates at 300+ edge cities worldwide. No container boot, no runtime warm-up.
       </p>
       <div className="comparison-table-wrap">
         <table>
@@ -258,10 +259,10 @@ function SpeedSection() {
 function ScalingSection() {
   return (
     <section className="features-section">
-      <h2>Why Infinite Scaling?</h2>
+      <h2>Why Scale-Out by Design?</h2>
       <p className="section-subtitle">
-        Scale to millions of independent databases — per user, per workspace, per tenant, however
-        you design it — without changing your code or schema.
+        Split data across independent DB blocks — per user, per workspace, per tenant, however you
+        design it — without redesigning around a central app-server bottleneck.
       </p>
       <div className="features-grid">
         <div className="feature-card">
@@ -299,7 +300,7 @@ const features = [
     icon: '🗄️',
     title: 'Database',
     description:
-      'SQLite across D1 and Durable Objects — full SQL, JOINs, transactions, FTS5 full-text search (CJK included), automatic schema migrations, and UUID v7 cursor pagination.',
+      'SQLite across D1 and Durable Objects — full SQL, JOINs, transactions, FTS5 full-text search (CJK included), automatic schema migrations, UUID v7 cursor pagination, plus PostgreSQL-backed static blocks when you need them.',
   },
   {
     icon: '🔐',
@@ -368,7 +369,7 @@ function DeploySection() {
           <code className="deploy-cmd">npx edgebase deploy</code>
           <ul className="deploy-features">
             <li>~0ms cold start</li>
-            <li>300+ global locations</li>
+            <li>300+ global cities</li>
             <li>Auto-scaling</li>
             <li>From $5/month (all projects)</li>
           </ul>


### PR DESCRIPTION
## Summary
- align the README, homepage hero, and docs entry pages around the same architecture-first framing
- replace over-broad cost/scaling claims with more precise wording around egress or bandwidth fees, ~0ms cold starts, and scale-out by design
- rewrite PostgreSQL trade-off copy to describe EdgeBase support directly instead of pointing readers to competitors

## Validation
- pnpm --dir docs build

## Notes
- pnpm --dir docs typecheck still fails because of an existing `Link` JSX typing mismatch in `docs/src/pages/index.tsx`