### PR TITLE
chore: bump release version to 0.2.6

### DIFF
--- a/docs/docs/push/client-sdk.md
+++ b/docs/docs/push/client-sdk.md
@@ -216,7 +216,7 @@ Chrome 50+, Firefox 44+, Edge 17+, Safari 16+, Opera 42+
 dependencies:
   firebase_core: ^3.0.0
   firebase_messaging: ^15.0.0
-  edgebase_flutter: ^0.2.5
+  edgebase_flutter: ^0.2.6
 ```
 
 3. Initialize Firebase:

--- a/docs/docs/room/client-sdk.md
+++ b/docs/docs/room/client-sdk.md
@@ -57,7 +57,7 @@ npm install @edge-base/react-native
 ```yaml
 # pubspec.yaml
 dependencies:
-  edgebase_flutter: ^0.2.5
+  edgebase_flutter: ^0.2.6
 ```
 
 ```bash

--- a/docs/docs/sdks/overview.md
+++ b/docs/docs/sdks/overview.md
@@ -120,7 +120,7 @@ final admin = AdminEdgeBase(
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/edge-base/edgebase-swift", from: "0.2.5")
+    .package(url: "https://github.com/edge-base/edgebase-swift", from: "0.2.6")
 ]
 ```
 
@@ -144,7 +144,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.edge-base.edgebase:edgebase-client:v0.2.5")
+    implementation("com.github.edge-base.edgebase:edgebase-client:v0.2.6")
 }
 ```
 
@@ -164,7 +164,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.5")
+    implementation("com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.6")
 }
 ```
 
@@ -192,7 +192,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.edge-base.edgebase:edgebase-android-java:v0.2.5'
+    implementation 'com.github.edge-base.edgebase:edgebase-android-java:v0.2.6'
 }
 ```
 
@@ -212,7 +212,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.edge-base.edgebase:edgebase-admin-java:v0.2.5'
+    implementation 'com.github.edge-base.edgebase:edgebase-admin-java:v0.2.6'
 }
 ```
 
@@ -236,7 +236,7 @@ AdminEdgeBase admin = EdgeBase.admin(
 // build.sbt
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.github.edge-base.edgebase" % "edgebase-admin-scala" % "v0.2.5"
+libraryDependencies += "com.github.edge-base.edgebase" % "edgebase-admin-scala" % "v0.2.6"
 ```
 
 ```scala
@@ -321,7 +321,7 @@ $admin = new AdminClient('https://your-project.edgebase.fun', getenv('EDGEBASE_S
 ```toml
 # Cargo.toml
 [dependencies]
-edgebase-admin = "0.2.5"
+edgebase-admin = "0.2.6"
 tokio = "1"
 serde_json = "1"
 ```
@@ -413,7 +413,7 @@ admin = EdgebaseAdmin::AdminClient.new(
 # mix.exs
 defp deps do
   [
-    {:edgebase_admin, "~> 0.2.5"}
+    {:edgebase_admin, "~> 0.2.6"}
   ]
 end
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "edgebase",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "type": "module",
     "private": true,
     "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/cli",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "CLI for EdgeBase — create, develop, and deploy EdgeBase projects",
     "license": "MIT",
     "repository": {

--- a/packages/create-edgebase/package.json
+++ b/packages/create-edgebase/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-edgebase",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "Bootstrap a new EdgeBase project",
     "license": "MIT",
     "repository": {

--- a/packages/plugins/core/package.json
+++ b/packages/plugins/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/plugin-core",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase plugin authoring helpers and public plugin contracts",
     "license": "MIT",
     "repository": {

--- a/packages/sdk/cpp/EdgeBase.uplugin
+++ b/packages/sdk/cpp/EdgeBase.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.2.5",
+  "VersionName": "0.2.6",
   "FriendlyName": "EdgeBase",
   "Description": "EdgeBase client SDK plugin for Unreal Engine 5.",
   "Category": "Online",

--- a/packages/sdk/csharp/packages/admin/EdgeBase.Admin.csproj
+++ b/packages/sdk/csharp/packages/admin/EdgeBase.Admin.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
     <PackageId>dev.edgebase.admin</PackageId>
-    <Version>0.2.5</Version>
+    <Version>0.2.6</Version>
     <Description>EdgeBase Admin SDK for .NET - server-side auth, SQL, storage, push, analytics, KV, D1, and Vectorize</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://edgebase.fun/docs/database/admin-sdk</PackageProjectUrl>

--- a/packages/sdk/csharp/packages/core/EdgeBase.Core.csproj
+++ b/packages/sdk/csharp/packages/core/EdgeBase.Core.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
     <PackageId>dev.edgebase.core</PackageId>
-    <Version>0.2.5</Version>
+    <Version>0.2.6</Version>
     <Description>EdgeBase Core SDK for .NET - low-level HTTP, database, storage, push, and field-operation primitives</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://edgebase.fun/docs/database/client-sdk</PackageProjectUrl>

--- a/packages/sdk/csharp/packages/unity/DatabaseLiveClient.cs
+++ b/packages/sdk/csharp/packages/unity/DatabaseLiveClient.cs
@@ -130,7 +130,7 @@ internal sealed class DatabaseLiveClient : IDisposable
                 {
                     ["type"]       = "auth",
                     ["token"]      = token,
-                    ["sdkVersion"] = "0.2.5",
+                    ["sdkVersion"] = "0.2.6",
                 });
                 var authBytes = Encoding.UTF8.GetBytes(authMsg);
                 await _ws.SendAsync(new ArraySegment<byte>(authBytes), WebSocketMessageType.Text, true, _cts.Token).ConfigureAwait(false);
@@ -516,7 +516,7 @@ internal sealed class DatabaseLiveClient : IDisposable
         {
             ["type"] = "auth",
             ["token"] = token,
-            ["sdkVersion"] = "0.2.5",
+            ["sdkVersion"] = "0.2.6",
         });
         var bytes = Encoding.UTF8.GetBytes(json);
         _ = _ws.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, _cts.Token);

--- a/packages/sdk/csharp/packages/unity/EdgeBase.Unity.csproj
+++ b/packages/sdk/csharp/packages/unity/EdgeBase.Unity.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
     <PackageId>dev.edgebase.unity</PackageId>
-    <Version>0.2.5</Version>
+    <Version>0.2.6</Version>
     <Description>EdgeBase Unity client SDK for .NET Standard 2.1 - auth, database, realtime, rooms, storage, functions, analytics, and push</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://edgebase.fun/docs/database/client-sdk</PackageProjectUrl>

--- a/packages/sdk/dart/packages/admin/pubspec.yaml
+++ b/packages/sdk/dart/packages/admin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: edgebase_admin
 description: EdgeBase Admin SDK — server-side admin operations.
-version: 0.2.5
+version: 0.2.6
 homepage: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart/packages/admin
 repository: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart/packages/admin
 
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  edgebase_core: ^0.2.5
+  edgebase_core: ^0.2.6
   http: ^1.2.0
 
 dev_dependencies:

--- a/packages/sdk/dart/packages/core/pubspec.yaml
+++ b/packages/sdk/dart/packages/core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: edgebase_core
 description: EdgeBase Core SDK — shared types, HTTP client, and table/storage operations.
-version: 0.2.5
+version: 0.2.6
 homepage: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart/packages/core
 repository: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart/packages/core
 

--- a/packages/sdk/dart/packages/flutter/lib/src/database_live_client.dart
+++ b/packages/sdk/dart/packages/flutter/lib/src/database_live_client.dart
@@ -196,7 +196,7 @@ class DatabaseLiveClient implements core.DatabaseLiveClient {
     _channel!.sink.add(jsonEncode({
       'type': 'auth',
       'token': token,
-      'sdkVersion': '0.2.5',
+      'sdkVersion': '0.2.6',
       if (ctx.isNotEmpty) 'context': ctx,
     }));
 
@@ -558,7 +558,7 @@ class DatabaseLiveClient implements core.DatabaseLiveClient {
     _channel!.sink.add(jsonEncode({
       'type': 'auth',
       'token': token,
-      'sdkVersion': '0.2.5',
+      'sdkVersion': '0.2.6',
       if (ctx.isNotEmpty) 'context': ctx,
     }));
   }

--- a/packages/sdk/dart/packages/flutter/pubspec.yaml
+++ b/packages/sdk/dart/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: edgebase_flutter
 description: EdgeBase Flutter/Dart SDK — client-side auth, database-live, and more.
-version: 0.2.5
+version: 0.2.6
 homepage: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart/packages/flutter
 repository: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart/packages/flutter
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  edgebase_core: ^0.2.5
+  edgebase_core: ^0.2.6
   http: ^1.2.0
   js: ^0.7.2
   shared_preferences: ^2.2.0

--- a/packages/sdk/dart/pubspec.yaml
+++ b/packages/sdk/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: edgebase
 description: EdgeBase Flutter/Dart SDK — 오픈소스 Global Edge BaaS
-version: 0.2.5
+version: 0.2.6
 homepage: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart
 repository: https://github.com/edge-base/edgebase/tree/main/packages/sdk/dart
 
@@ -15,8 +15,8 @@ dependencies:
   http_parser: ^4.0.0
   web_socket_channel: ^3.0.0
   shared_preferences: ^2.2.0
-  edgebase_core: ^0.2.5
-  edgebase_flutter: ^0.2.5
+  edgebase_core: ^0.2.6
+  edgebase_flutter: ^0.2.6
 
 dev_dependencies:
   flutter_test:

--- a/packages/sdk/elixir/packages/admin/README.md
+++ b/packages/sdk/elixir/packages/admin/README.md
@@ -58,7 +58,7 @@ You can find it:
 ## Installation
 
 ```elixir
-{:edgebase_admin, "~> 0.2.5"}
+{:edgebase_admin, "~> 0.2.6"}
 ```
 
 If you consume the monorepo directly, use the path dependency already configured in this repository.

--- a/packages/sdk/elixir/packages/admin/mix.exs
+++ b/packages/sdk/elixir/packages/admin/mix.exs
@@ -4,7 +4,7 @@ defmodule EdgeBaseAdmin.MixProject do
   def project do
     [
       app: :edgebase_admin,
-      version: "0.2.5",
+      version: "0.2.6",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -23,7 +23,7 @@ defmodule EdgeBaseAdmin.MixProject do
 
   defp deps do
     [
-      {:edgebase_core, "~> 0.2.5", path: "../core"},
+      {:edgebase_core, "~> 0.2.6", path: "../core"},
       {:jason, "~> 1.4"}
     ]
   end

--- a/packages/sdk/elixir/packages/core/README.md
+++ b/packages/sdk/elixir/packages/core/README.md
@@ -48,7 +48,7 @@ You can find it:
 ## Installation
 
 ```elixir
-{:edgebase_core, "~> 0.2.5"}
+{:edgebase_core, "~> 0.2.6"}
 ```
 
 If you consume the monorepo directly, use the path dependency already configured in this repository.

--- a/packages/sdk/elixir/packages/core/mix.exs
+++ b/packages/sdk/elixir/packages/core/mix.exs
@@ -4,7 +4,7 @@ defmodule EdgeBaseCore.MixProject do
   def project do
     [
       app: :edgebase_core,
-      version: "0.2.5",
+      version: "0.2.6",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/packages/sdk/java/README.md
+++ b/packages/sdk/java/README.md
@@ -9,9 +9,9 @@
 Official Java SDK for EdgeBase, published for Gradle and Maven consumers through
 JitPack as three installable artifacts:
 
-- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.6`
 
 The monorepo root `edgebase-sdk-java` artifact is intentionally not part of the
 public JitPack install path. Depend on the split artifacts below.
@@ -30,9 +30,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.edge-base.edgebase:edgebase-core-java:v0.2.5'
-    implementation 'com.github.edge-base.edgebase:edgebase-android-java:v0.2.5'
-    implementation 'com.github.edge-base.edgebase:edgebase-admin-java:v0.2.5'
+    implementation 'com.github.edge-base.edgebase:edgebase-core-java:v0.2.6'
+    implementation 'com.github.edge-base.edgebase:edgebase-android-java:v0.2.6'
+    implementation 'com.github.edge-base.edgebase:edgebase-admin-java:v0.2.6'
 }
 ```
 
@@ -49,17 +49,17 @@ dependencies {
 <dependency>
     <groupId>com.github.edge-base.edgebase</groupId>
     <artifactId>edgebase-core-java</artifactId>
-    <version>v0.2.5</version>
+    <version>v0.2.6</version>
 </dependency>
 <dependency>
     <groupId>com.github.edge-base.edgebase</groupId>
     <artifactId>edgebase-android-java</artifactId>
-    <version>v0.2.5</version>
+    <version>v0.2.6</version>
 </dependency>
 <dependency>
     <groupId>com.github.edge-base.edgebase</groupId>
     <artifactId>edgebase-admin-java</artifactId>
-    <version>v0.2.5</version>
+    <version>v0.2.6</version>
 </dependency>
 ```
 

--- a/packages/sdk/java/build.gradle
+++ b/packages/sdk/java/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'maven-publish'
 }
 
-def edgebaseReleaseVersion = '0.2.5'
+def edgebaseReleaseVersion = '0.2.6'
 def edgebaseGroup = System.getenv('JITPACK') ? 'com.github.edge-base.edgebase' : 'dev.edgebase'
 def edgebaseVersion = System.getenv('JITPACK') ? (System.getenv('VERSION') ?: "v${edgebaseReleaseVersion}") : edgebaseReleaseVersion
 

--- a/packages/sdk/java/llms.txt
+++ b/packages/sdk/java/llms.txt
@@ -26,10 +26,10 @@ batch jobs, and operational tooling that hold a Service Key.
 ## Public Artifacts
 
 - JitPack group: `com.github.edge-base.edgebase`
-- tags are versioned with the leading `v`, for example `v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.5`
+- tags are versioned with the leading `v`, for example `v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.6`
 - do not recommend the root `edgebase-sdk-java` artifact for public installs
 
 ## Canonical Examples

--- a/packages/sdk/java/packages/admin/README.md
+++ b/packages/sdk/java/packages/admin/README.md
@@ -59,7 +59,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.edge-base.edgebase:edgebase-admin-java:v0.2.5")
+    implementation("com.github.edge-base.edgebase:edgebase-admin-java:v0.2.6")
 }
 ```
 

--- a/packages/sdk/java/packages/admin/llms.txt
+++ b/packages/sdk/java/packages/admin/llms.txt
@@ -21,7 +21,7 @@ Do not ship this package to Android apps, browser bundles, or untrusted clients.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.6`
 
 ## Canonical Examples
 

--- a/packages/sdk/java/packages/android/README.md
+++ b/packages/sdk/java/packages/android/README.md
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.edge-base.edgebase:edgebase-android-java:v0.2.5'
+    implementation 'com.github.edge-base.edgebase:edgebase-android-java:v0.2.6'
 }
 ```
 

--- a/packages/sdk/java/packages/android/llms.txt
+++ b/packages/sdk/java/packages/android/llms.txt
@@ -19,7 +19,7 @@ code. For backend code, prefer `edgebase-admin-java`.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.6`
 
 ## Canonical Examples
 

--- a/packages/sdk/java/packages/android/src/main/java/dev/edgebase/sdk/client/DatabaseLiveClient.java
+++ b/packages/sdk/java/packages/android/src/main/java/dev/edgebase/sdk/client/DatabaseLiveClient.java
@@ -40,7 +40,7 @@ import java.util.function.Consumer;
  */
 class DatabaseLiveClient implements dev.edgebase.sdk.core.DatabaseLiveClient {
     private static final Gson gson = new Gson();
-    private static final String SDK_VERSION = "0.2.5";
+    private static final String SDK_VERSION = "0.2.6";
 
     private final String url;
     private final TokenManager tokenManager;
@@ -223,7 +223,7 @@ class DatabaseLiveClient implements dev.edgebase.sdk.core.DatabaseLiveClient {
     // ─── Auth ───
 
     /**
-     * Send a {@code {"type":"auth","token":"...","sdkVersion":"0.2.5"}} message.
+     * Send a {@code {"type":"auth","token":"...","sdkVersion":"0.2.6"}} message.
      * This is the only auth mechanism the server accepts for WebSocket connections.
      */
     private void sendAuthMessage() {

--- a/packages/sdk/java/packages/core/README.md
+++ b/packages/sdk/java/packages/core/README.md
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.edge-base.edgebase:edgebase-core-java:v0.2.5'
+    implementation 'com.github.edge-base.edgebase:edgebase-core-java:v0.2.6'
 }
 ```
 

--- a/packages/sdk/java/packages/core/llms.txt
+++ b/packages/sdk/java/packages/core/llms.txt
@@ -18,7 +18,7 @@ It supplies the shared primitives used by both higher-level Java SDKs.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.6`
 
 ## Canonical Examples
 

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/sdk",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "private": true,
     "description": "EdgeBase SDK — unified JavaScript/TypeScript client for EdgeBase",
     "license": "MIT",

--- a/packages/sdk/js/packages/admin/package.json
+++ b/packages/sdk/js/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/admin",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase admin SDK — server-side client for user management, database admin, and analytics",
     "license": "MIT",
     "repository": {

--- a/packages/sdk/js/packages/auth-ui-react/package.json
+++ b/packages/sdk/js/packages/auth-ui-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/auth-ui-react",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase Auth UI for React — pre-built authentication components",
     "license": "MIT",
     "repository": {

--- a/packages/sdk/js/packages/core/package.json
+++ b/packages/sdk/js/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/core",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase core SDK — platform-agnostic client for auth, database, storage, and functions",
     "license": "MIT",
     "repository": {

--- a/packages/sdk/js/packages/ssr/package.json
+++ b/packages/sdk/js/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/ssr",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase SSR helpers — cookie-based token management for server-side rendering",
     "license": "MIT",
     "repository": {

--- a/packages/sdk/js/packages/web/package.json
+++ b/packages/sdk/js/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/web",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase web SDK — browser client with database-live subscriptions, room, and auth persistence",
     "license": "MIT",
     "repository": {

--- a/packages/sdk/js/packages/web/src/database-live.ts
+++ b/packages/sdk/js/packages/web/src/database-live.ts
@@ -239,7 +239,7 @@ export class DatabaseLiveClient implements IDatabaseLiveSubscriber {
       );
     }
 
-    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.5' });
+    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.6' });
 
     return new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -443,7 +443,7 @@ export class DatabaseLiveClient implements IDatabaseLiveSubscriber {
   private refreshAuth(): void {
     const token = this.tokenManager.currentAccessToken;
     if (!token || !this.ws || !this.connected) return;
-    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.5' });
+    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.6' });
   }
 
   private handleAuthStateChange(user: TokenUser | null): void {

--- a/packages/sdk/kotlin/README.md
+++ b/packages/sdk/kotlin/README.md
@@ -25,9 +25,9 @@ This package is one part of the wider EdgeBase platform. For the full platform, 
 
 | Module | Artifact | Targets |
 | --- | --- | --- |
-| `:core` | `com.github.edge-base.edgebase:edgebase-core:v0.2.5` | current JitPack route publishes the JVM variant of the shared runtime |
-| `:client` | `com.github.edge-base.edgebase:edgebase-client:v0.2.5` | current JitPack route publishes the JVM variant of the client runtime; built-in Room Media ships on Android/iOS/JS and adapter-driven Room Media is available on JVM |
-| `:admin` | `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.5` | JVM only |
+| `:core` | `com.github.edge-base.edgebase:edgebase-core:v0.2.6` | current JitPack route publishes the JVM variant of the shared runtime |
+| `:client` | `com.github.edge-base.edgebase:edgebase-client:v0.2.6` | current JitPack route publishes the JVM variant of the client runtime; built-in Room Media ships on Android/iOS/JS and adapter-driven Room Media is available on JVM |
+| `:admin` | `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.6` | JVM only |
 
 If you build from the monorepo directly, depend on the Gradle modules under
 `packages/sdk/kotlin`. That path remains the way to consume the full Android, iOS,
@@ -43,9 +43,9 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.edge-base.edgebase:edgebase-core:v0.2.5")
-    implementation("com.github.edge-base.edgebase:edgebase-client:v0.2.5")
-    implementation("com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.5")
+    implementation("com.github.edge-base.edgebase:edgebase-core:v0.2.6")
+    implementation("com.github.edge-base.edgebase:edgebase-client:v0.2.6")
+    implementation("com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.6")
 }
 ```
 
@@ -127,7 +127,7 @@ Read more:
 
 ## Publication Notes
 
-- JitPack versions use the repository tag, for example `v0.2.5`
+- JitPack versions use the repository tag, for example `v0.2.6`
 - the public JitPack route validates the JVM publications of `:core` and `:client`
 - the umbrella root artifact `edgebase-kotlin` is intentionally excluded from public installs
 

--- a/packages/sdk/kotlin/admin/README.md
+++ b/packages/sdk/kotlin/admin/README.md
@@ -59,7 +59,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.5")
+    implementation("com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.6")
 }
 ```
 

--- a/packages/sdk/kotlin/admin/llms.txt
+++ b/packages/sdk/kotlin/admin/llms.txt
@@ -21,7 +21,7 @@ Do not ship this package to Android apps, browser bundles, or other untrusted cl
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.6`
 
 ## Canonical Examples
 

--- a/packages/sdk/kotlin/build.gradle.kts
+++ b/packages/sdk/kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     id("com.android.library") version "8.2.0" apply false
 }
 
-val edgebaseReleaseVersion = "0.2.5"
+val edgebaseReleaseVersion = "0.2.6"
 val edgebaseGroup = if (System.getenv("JITPACK").isNullOrBlank()) {
     "dev.edgebase"
 } else {

--- a/packages/sdk/kotlin/client/README.md
+++ b/packages/sdk/kotlin/client/README.md
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.edge-base.edgebase:edgebase-client:v0.2.5")
+    implementation("com.github.edge-base.edgebase:edgebase-client:v0.2.6")
 }
 ```
 

--- a/packages/sdk/kotlin/client/llms.txt
+++ b/packages/sdk/kotlin/client/llms.txt
@@ -19,7 +19,7 @@ Kotlin admin module instead.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-client:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-client:v0.2.6`
 - this is the current JitPack JVM publication for the shared `:client` module
 
 ## Canonical Examples

--- a/packages/sdk/kotlin/client/src/commonMain/kotlin/dev/edgebase/sdk/client/DatabaseLiveClient.kt
+++ b/packages/sdk/kotlin/client/src/commonMain/kotlin/dev/edgebase/sdk/client/DatabaseLiveClient.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.json.*
 
-private const val SDK_VERSION = "0.2.5"
+private const val SDK_VERSION = "0.2.6"
 
 // MARK: - FilterTuple
 
@@ -78,7 +78,7 @@ private fun matchesDatabaseLiveChannel(channel: String, change: DbChange, messag
  * Database live client using Ktor WebSocket with automatic reconnection.
  *
  * Authentication is performed via WebSocket message (not HTTP headers):
- * after the WS session opens, we send `{"type":"auth","token":"...","sdkVersion":"0.2.5"}`
+ * after the WS session opens, we send `{"type":"auth","token":"...","sdkVersion":"0.2.6"}`
  * and wait for `auth_success` or `auth_refreshed` before signaling ready.
  */
 internal class DatabaseLiveClient(

--- a/packages/sdk/kotlin/core/README.md
+++ b/packages/sdk/kotlin/core/README.md
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.edge-base.edgebase:edgebase-core:v0.2.5")
+    implementation("com.github.edge-base.edgebase:edgebase-core:v0.2.6")
 }
 ```
 

--- a/packages/sdk/kotlin/core/llms.txt
+++ b/packages/sdk/kotlin/core/llms.txt
@@ -18,7 +18,7 @@ entrypoints.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-core:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-core:v0.2.6`
 - this is the current JitPack JVM publication for the shared `:core` module
 
 ## Canonical Examples

--- a/packages/sdk/kotlin/llms.txt
+++ b/packages/sdk/kotlin/llms.txt
@@ -25,10 +25,10 @@ service code, and the `:core` module provides the shared KMP runtime used by bot
 ## Public Artifacts
 
 - JitPack group: `com.github.edge-base.edgebase`
-- tags are versioned with the leading `v`, for example `v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-core:v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-client:v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.5`
+- tags are versioned with the leading `v`, for example `v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-core:v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-client:v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.6`
 - the current public JitPack route validates the JVM publications of `:core` and `:client`
 - do not recommend the root `edgebase-kotlin` artifact for public installs
 

--- a/packages/sdk/php/packages/admin/composer.json
+++ b/packages/sdk/php/packages/admin/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "edgebase/core": "^0.2.5"
+        "edgebase/core": "^0.2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0"
@@ -32,7 +32,7 @@
             "url": "../core",
             "options": {
                 "versions": {
-                    "edgebase/core": "0.2.5"
+                    "edgebase/core": "0.2.6"
                 }
             }
         }

--- a/packages/sdk/python/packages/admin/README.md
+++ b/packages/sdk/python/packages/admin/README.md
@@ -123,5 +123,5 @@ print(len(users.get("users", [])), len(posts.items), rows, signed.url)
 ## Requirements
 
 - Python `3.10+`
-- `edgebase-core>=0.2.5,<0.3.0`
+- `edgebase-core>=0.2.6,<0.3.0`
 - A valid EdgeBase Service Key

--- a/packages/sdk/python/packages/admin/pyproject.toml
+++ b/packages/sdk/python/packages/admin/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "edgebase-admin"
-version = "0.2.5"
+version = "0.2.6"
 description = "Python admin SDK for EdgeBase service-key workloads"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,7 +12,7 @@ license = "MIT"
 authors = [
     { name = "EdgeBase Team" }
 ]
-dependencies = ["edgebase-core>=0.2.5,<0.3.0"]
+dependencies = ["edgebase-core>=0.2.6,<0.3.0"]
 
 [project.urls]
 Homepage = "https://github.com/edge-base/edgebase/tree/main/packages/sdk/python/packages/admin"

--- a/packages/sdk/python/packages/core/pyproject.toml
+++ b/packages/sdk/python/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "edgebase-core"
-version = "0.2.5"
+version = "0.2.6"
 description = "Shared Python core for EdgeBase table, storage, and HTTP primitives"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/sdk/python/pyproject.toml
+++ b/packages/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "edgebase"
-version = "0.2.5"
+version = "0.2.6"
 description = "Unified Python SDK for trusted EdgeBase server environments"
 readme = "README.md"
 license = "MIT"
@@ -14,8 +14,8 @@ authors = [
 ]
 
 dependencies = [
-    "edgebase-core>=0.2.5,<0.3.0",
-    "edgebase-admin>=0.2.5,<0.3.0",
+    "edgebase-core>=0.2.6,<0.3.0",
+    "edgebase-admin>=0.2.6,<0.3.0",
     "httpx>=0.27",
     "websockets>=12.0",
 ]

--- a/packages/sdk/python/src/edgebase/__init__.py
+++ b/packages/sdk/python/src/edgebase/__init__.py
@@ -29,7 +29,7 @@ from edgebase.room import RoomClient, Subscription
 try:
     __version__ = version("edgebase")
 except PackageNotFoundError:
-    __version__ = "0.2.5"
+    __version__ = "0.2.6"
 
 __all__ = [
     "EdgeBaseServer",

--- a/packages/sdk/react-native/package.json
+++ b/packages/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/react-native",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase React Native SDK — iOS, Android, Web support",
     "license": "MIT",
     "repository": {

--- a/packages/sdk/react-native/src/database-live.ts
+++ b/packages/sdk/react-native/src/database-live.ts
@@ -223,7 +223,7 @@ export class DatabaseLiveClient implements IDatabaseLiveSubscriber {
       refreshAccessToken(this.baseUrl, refreshToken),
     );
     if (!token) throw new EdgeBaseError(401, 'No access token available. Sign in first.');
-    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.5' });
+    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.6' });
 
     return new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => reject(new EdgeBaseError(401, 'Auth timeout')), 10000);
@@ -355,7 +355,7 @@ export class DatabaseLiveClient implements IDatabaseLiveSubscriber {
   private refreshAuth(): void {
     const token = this.tokenManager.currentAccessToken;
     if (!token || !this.ws || !this.connected) return;
-    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.5' });
+    this.sendRaw({ type: 'auth', token, sdkVersion: '0.2.6' });
   }
 
   private handleAuthStateChange(user: TokenUser | null): void {

--- a/packages/sdk/ruby/packages/admin/edgebase_admin.gemspec
+++ b/packages/sdk/ruby/packages/admin/edgebase_admin.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "edgebase_admin"
-  spec.version       = "0.2.5"
+  spec.version       = "0.2.6"
   spec.summary       = "EdgeBase Admin SDK for Ruby — server-side admin operations."
   spec.description   = "Admin module for EdgeBase Ruby SDK. Provides AdminClient, AdminAuthClient, " \
                         "KvClient, D1Client, VectorizeClient, PushClient via Service Key auth."
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*.rb"] + %w[README.md llms.txt LICENSE]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "edgebase_core", "~> 0.2.5"
+  spec.add_dependency "edgebase_core", "~> 0.2.6"
 end

--- a/packages/sdk/ruby/packages/core/edgebase_core.gemspec
+++ b/packages/sdk/ruby/packages/core/edgebase_core.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "edgebase_core"
-  spec.version       = "0.2.5"
+  spec.version       = "0.2.6"
   spec.summary       = "EdgeBase Core SDK for Ruby — shared HTTP client, query builder, and storage."
   spec.description   = "Core module for EdgeBase Ruby SDK. Provides HttpClient, TableRef, DocRef, " \
                         "StorageClient, and generated API layer from OpenAPI spec."

--- a/packages/sdk/rust/Cargo.toml
+++ b/packages/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgebase-sdk"
-version = "0.2.5"
+version = "0.2.6"
 description = "Workspace release line for the EdgeBase Rust SDKs"
 edition = "2021"
 license = "MIT"

--- a/packages/sdk/rust/README.md
+++ b/packages/sdk/rust/README.md
@@ -61,14 +61,14 @@ For published application code, prefer the narrower crates:
 
 ```toml
 [dependencies]
-edgebase-admin = "0.2.5"
+edgebase-admin = "0.2.6"
 ```
 
 Or for lower-level primitives:
 
 ```toml
 [dependencies]
-edgebase-core = "0.2.5"
+edgebase-core = "0.2.6"
 ```
 
 The current public Rust release unit focuses on `edgebase-core` and `edgebase-admin`.

--- a/packages/sdk/rust/packages/admin/Cargo.toml
+++ b/packages/sdk/rust/packages/admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgebase-admin"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "EdgeBase Admin SDK — server-side admin operations"
 license = "MIT"
@@ -10,7 +10,7 @@ repository = "https://github.com/edge-base/edgebase"
 documentation = "https://edgebase.fun/docs/admin-sdk/reference"
 
 [dependencies]
-edgebase-core = { version = "0.2.5", path = "../core" }
+edgebase-core = { version = "0.2.6", path = "../core" }
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk/rust/packages/admin/README.md
+++ b/packages/sdk/rust/packages/admin/README.md
@@ -60,7 +60,7 @@ For published applications:
 
 ```toml
 [dependencies]
-edgebase-admin = "0.2.5"
+edgebase-admin = "0.2.6"
 ```
 
 Or:

--- a/packages/sdk/rust/packages/core/Cargo.toml
+++ b/packages/sdk/rust/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgebase-core"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "EdgeBase Core — shared types and HTTP client"
 license = "MIT"

--- a/packages/sdk/rust/packages/core/README.md
+++ b/packages/sdk/rust/packages/core/README.md
@@ -51,7 +51,7 @@ For published applications:
 
 ```toml
 [dependencies]
-edgebase-core = "0.2.5"
+edgebase-core = "0.2.6"
 ```
 
 Or:

--- a/packages/sdk/rust/packages/core/src/room.rs
+++ b/packages/sdk/rust/packages/core/src/room.rs
@@ -996,7 +996,7 @@ impl RoomClient {
         let (mut write, mut read) = ws_stream.split();
 
         // Auth
-        let auth = json!({"type": "auth", "token": (self.token_fn)(), "sdkVersion": "0.2.5"});
+        let auth = json!({"type": "auth", "token": (self.token_fn)(), "sdkVersion": "0.2.6"});
         write.send(Message::Text(auth.to_string().into())).await?;
 
         // Wait for auth_success

--- a/packages/sdk/scala/README.md
+++ b/packages/sdk/scala/README.md
@@ -17,8 +17,8 @@ This package is one part of the wider EdgeBase platform. For the full platform, 
 
 | Module | Artifact | Notes |
 | --- | --- | --- |
-| `:packages:core` | `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.5` | Scala wrappers for DB, storage, and shared result types |
-| `:packages:admin` | `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.5` | Server-side admin SDK built on top of the Java admin SDK |
+| `:packages:core` | `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.6` | Scala wrappers for DB, storage, and shared result types |
+| `:packages:admin` | `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.6` | Server-side admin SDK built on top of the Java admin SDK |
 
 If you build from the monorepo directly, depend on the Scala projects under
 `packages/sdk/scala`.
@@ -29,8 +29,8 @@ If you build from the monorepo directly, depend on the Scala projects under
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
-  "com.github.edge-base.edgebase" % "edgebase-core-scala" % "v0.2.5",
-  "com.github.edge-base.edgebase" % "edgebase-admin-scala" % "v0.2.5"
+  "com.github.edge-base.edgebase" % "edgebase-core-scala" % "v0.2.6",
+  "com.github.edge-base.edgebase" % "edgebase-admin-scala" % "v0.2.6"
 )
 ```
 

--- a/packages/sdk/scala/build.gradle.kts
+++ b/packages/sdk/scala/build.gradle.kts
@@ -1,4 +1,4 @@
-val edgebaseReleaseVersion = "0.2.5"
+val edgebaseReleaseVersion = "0.2.6"
 val edgebaseGroup = if (System.getenv("JITPACK").isNullOrBlank()) {
     "dev.edgebase"
 } else {

--- a/packages/sdk/scala/llms.txt
+++ b/packages/sdk/scala/llms.txt
@@ -25,9 +25,9 @@ the `:packages:admin` module exposes the trusted admin SDK for backend code.
 ## Public Artifacts
 
 - JitPack group: `com.github.edge-base.edgebase`
-- tags are versioned with the leading `v`, for example `v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.5`
-- `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.5`
+- tags are versioned with the leading `v`, for example `v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.6`
+- `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.6`
 - do not recommend the root `edgebase-scala` artifact for public installs
 
 ## Canonical Examples

--- a/packages/sdk/scala/packages/admin/README.md
+++ b/packages/sdk/scala/packages/admin/README.md
@@ -56,7 +56,7 @@ You can find it:
 ```scala
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.github.edge-base.edgebase" % "edgebase-admin-scala" % "v0.2.5"
+libraryDependencies += "com.github.edge-base.edgebase" % "edgebase-admin-scala" % "v0.2.6"
 ```
 
 This package wraps the Java admin runtime, so it stays JVM-only and publishes as a single Scala/JVM artifact.

--- a/packages/sdk/scala/packages/admin/llms.txt
+++ b/packages/sdk/scala/packages/admin/llms.txt
@@ -21,7 +21,7 @@ Do not ship this package to browser bundles or untrusted clients. It is intended
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.6`
 
 ## Canonical Examples
 

--- a/packages/sdk/scala/packages/core/README.md
+++ b/packages/sdk/scala/packages/core/README.md
@@ -20,7 +20,7 @@ This package is one part of the wider EdgeBase platform. For the full platform, 
 ```scala
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.github.edge-base.edgebase" % "edgebase-core-scala" % "v0.2.5"
+libraryDependencies += "com.github.edge-base.edgebase" % "edgebase-core-scala" % "v0.2.6"
 ```
 
 If you are building from the monorepo directly, depend on `:packages:core`.

--- a/packages/sdk/scala/packages/core/llms.txt
+++ b/packages/sdk/scala/packages/core/llms.txt
@@ -19,7 +19,7 @@ Java core SDK instead.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.6`
 
 ## Canonical Examples
 

--- a/packages/sdk/swift/README.md
+++ b/packages/sdk/swift/README.md
@@ -25,7 +25,7 @@ Use the higher-level client package for most app and trusted-service workflows:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/edge-base/edgebase-swift", from: "0.2.5")
+    .package(url: "https://github.com/edge-base/edgebase-swift", from: "0.2.6")
 ]
 ```
 
@@ -33,7 +33,7 @@ If you only need the low-level shared primitives, install `EdgeBaseCore` directl
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/edge-base/edgebase-swift-core", from: "0.2.5")
+    .package(url: "https://github.com/edge-base/edgebase-swift-core", from: "0.2.6")
 ]
 ```
 

--- a/packages/sdk/swift/packages/core/README.md
+++ b/packages/sdk/swift/packages/core/README.md
@@ -21,7 +21,7 @@ Add the public core package repository to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/edge-base/edgebase-swift-core", from: "0.2.5")
+    .package(url: "https://github.com/edge-base/edgebase-swift-core", from: "0.2.6")
 ]
 ```
 

--- a/packages/sdk/swift/packages/ios/README.md
+++ b/packages/sdk/swift/packages/ios/README.md
@@ -22,7 +22,7 @@ Add the public client package repository to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/edge-base/edgebase-swift", from: "0.2.5")
+    .package(url: "https://github.com/edge-base/edgebase-swift", from: "0.2.6")
 ]
 ```
 

--- a/packages/sdk/swift/packages/ios/Sources/DatabaseLiveClient.swift
+++ b/packages/sdk/swift/packages/ios/Sources/DatabaseLiveClient.swift
@@ -69,7 +69,7 @@ private func matchesDatabaseLiveChannel(_ channel: String, change: DbChange, mes
 ///
 /// Auth flow (CRITICAL —):
 ///   1. Open WebSocket connection (no HTTP Authorization header)
-///   2. Send `{"type":"auth","token":"...","sdkVersion":"0.2.5"}` message
+///   2. Send `{"type":"auth","token":"...","sdkVersion":"0.2.6"}` message
 ///   3. Wait for `auth_success` or `auth_refreshed` before sending subscribe messages
 ///   4. On `auth_refreshed`: parse `revokedChannels`, clean up, re-subscribe remaining
 ///
@@ -312,7 +312,7 @@ final class DatabaseLiveClient: DatabaseLiveSubscribable, @unchecked Sendable {
 
     /// Authenticate via WebSocket message (not HTTP headers).
     ///
-    /// Sends `{"type":"auth","token":"...","sdkVersion":"0.2.5"}` and waits for
+    /// Sends `{"type":"auth","token":"...","sdkVersion":"0.2.6"}` and waits for
     /// `auth_success` or `auth_refreshed` response from the server.
     ///
     /// On `auth_refreshed`: parses `revokedChannels`, removes them
@@ -330,7 +330,7 @@ final class DatabaseLiveClient: DatabaseLiveSubscribable, @unchecked Sendable {
         let authMsg: [String: Any] = [
             "type": "auth",
             "token": token,
-            "sdkVersion": "0.2.5"
+            "sdkVersion": "0.2.6"
         ]
         try await sendMessage(authMsg)
 
@@ -603,7 +603,7 @@ final class DatabaseLiveClient: DatabaseLiveSubscribable, @unchecked Sendable {
             try? await self.sendMessage([
                 "type": "auth",
                 "token": token,
-                "sdkVersion": "0.2.5",
+                "sdkVersion": "0.2.6",
             ])
         }
     }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/server",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase runtime assets consumed by the EdgeBase CLI",
     "license": "MIT",
     "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@edge-base/shared",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "EdgeBase shared helpers for config, functions, and runtime contracts",
     "license": "MIT",
     "repository": {

--- a/skills/edgebase/references/generated/java-admin.md
+++ b/skills/edgebase/references/generated/java-admin.md
@@ -23,7 +23,7 @@ Do not ship this package to Android apps, browser bundles, or untrusted clients.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-admin-java:v0.2.6`
 
 ## Canonical Examples
 

--- a/skills/edgebase/references/generated/java-android.md
+++ b/skills/edgebase/references/generated/java-android.md
@@ -21,7 +21,7 @@ code. For backend code, prefer `edgebase-admin-java`.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-android-java:v0.2.6`
 
 ## Canonical Examples
 

--- a/skills/edgebase/references/generated/java-core.md
+++ b/skills/edgebase/references/generated/java-core.md
@@ -20,7 +20,7 @@ It supplies the shared primitives used by both higher-level Java SDKs.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-core-java:v0.2.6`
 
 ## Canonical Examples
 

--- a/skills/edgebase/references/generated/kotlin-admin.md
+++ b/skills/edgebase/references/generated/kotlin-admin.md
@@ -23,7 +23,7 @@ Do not ship this package to Android apps, browser bundles, or other untrusted cl
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-admin-kotlin:v0.2.6`
 
 ## Canonical Examples
 

--- a/skills/edgebase/references/generated/kotlin-client.md
+++ b/skills/edgebase/references/generated/kotlin-client.md
@@ -21,7 +21,7 @@ Kotlin admin module instead.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-client:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-client:v0.2.6`
 - this is the current JitPack JVM publication for the shared `:client` module
 
 ## Canonical Examples

--- a/skills/edgebase/references/generated/kotlin-core.md
+++ b/skills/edgebase/references/generated/kotlin-core.md
@@ -20,7 +20,7 @@ entrypoints.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-core:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-core:v0.2.6`
 - this is the current JitPack JVM publication for the shared `:core` module
 
 ## Canonical Examples

--- a/skills/edgebase/references/generated/scala-admin.md
+++ b/skills/edgebase/references/generated/scala-admin.md
@@ -23,7 +23,7 @@ Do not ship this package to browser bundles or untrusted clients. It is intended
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-admin-scala:v0.2.6`
 
 ## Canonical Examples
 

--- a/skills/edgebase/references/generated/scala-core.md
+++ b/skills/edgebase/references/generated/scala-core.md
@@ -21,7 +21,7 @@ Java core SDK instead.
 
 ## Public Artifact
 
-- `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.5`
+- `com.github.edge-base.edgebase:edgebase-core-scala:v0.2.6`
 
 ## Canonical Examples
 


### PR DESCRIPTION
## Summary
- bump the root release version to 0.2.6
- sync all file-backed package versions and versioned docs references
- regenerate generated skill references to keep install snippets aligned

## Verification
- pnpm release:check